### PR TITLE
feat!: Support bmson

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,13 @@ categories = ["parsing"]
 repository = "https://github.com/MikuroXina/bms-rs"
 
 [features]
+default = ["bmson"]
 serde = ["dep:serde"]
+bmson = ["dep:serde", "serde_json"]
 
 [dependencies]
 itertools = "0.10.5"
+num = "0.4.0"
 serde = { version = "1.0.152", features = ["derive"], optional = true }
+serde_json = { version = "1.0.96", optional = true }
+thiserror = "1.0.40"

--- a/src/bmson.rs
+++ b/src/bmson.rs
@@ -1,0 +1,389 @@
+//! The [bmson format](https://bmson-spec.readthedocs.io/en/master/doc/index.html) definition.
+
+// TODO: Document about order of processing notes.
+
+use std::{collections::HashMap, num::NonZeroU8};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{
+    lex::command::{JudgeLevel, Key},
+    parse::{notes::BgaLayer, Bms},
+    time::{ObjTime, Track},
+};
+
+use self::{
+    fin_f64::FinF64,
+    pulse::{PulseConverter, PulseNumber},
+};
+
+pub mod fin_f64;
+pub mod pulse;
+
+/// Top-level object for bmson format.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Bmson {
+    /// Version of bmson format, which should be compared using [Semantic Version 2.0.0](http://semver.org/spec/v2.0.0.html). Older bmson file may not have this field, but lacking this must be an error.
+    pub version: String,
+    /// Score metadata.
+    pub info: BmsonInfo,
+    /// Location of bar lines in pulses. If `None`, then a 4/4 beat is assumed and bar lines will be generates every 4 quarter notes. If `Some(vec![])`, this chart will not have any bar line.
+    ///
+    /// This format represents an irregular meter by bar lines.
+    pub lines: Option<Vec<BarLine>>,
+    /// Events of bpm change. If there are coincident events, the successor is only applied.
+    #[serde(default = "Vec::new")]
+    pub bpm_events: Vec<BpmEvent>,
+    /// Events of scroll stop. If there are coincident events, they are happened in succession.
+    #[serde(default = "Vec::new")]
+    pub stop_events: Vec<StopEvent>,
+    /// Note data.
+    pub sound_channels: Vec<SoundChannel>,
+    /// BGA data.
+    pub bga: Bga,
+}
+
+/// Header metadata of chart.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BmsonInfo {
+    /// Self explanatory title.
+    pub title: String,
+    /// Self explanatory subtitle.
+    #[serde(default)]
+    pub subtitle: String,
+    /// Author of the chart. It may multiple names such as `Alice vs Bob`, `Alice feat. Bob` and so on. But you should respect the value because it usually have special meaning.
+    pub artist: String,
+    /// Other authors of the chart. This is useful for indexing and searching.
+    ///
+    /// Value of the array has form of `key:value`. The `key` can be `music`, `vocal`, `chart`, `image`, `movie` or `other`. If it has no `key`, you should treat as that `key` equals to `other`. The value may contains the spaces before and after `key` and `value`, so you should trim them.
+    ///
+    /// # Example
+    ///
+    /// ```json
+    /// "subartists": ["music:5argon", "music:encX", "chart:flicknote", "movie:5argon", "image:5argon"]
+    /// ```
+    #[serde(default = "Vec::new")]
+    pub subartists: Vec<String>,
+    /// Self explanatory genre.
+    pub genre: String,
+    /// Hint for layout lanes, e.g. "beat-7k", "popn-5k", "generic-nkeys". Defaults to `"beat-7k"`.
+    ///
+    /// If you want to support many lane modes of BMS, you should check this to determine the layout for lanes. Also you can check all lane information in `sound_channels` for strict implementation.
+    #[serde(default = "default_mode_hint")]
+    pub mode_hint: String,
+    /// Special chart name, e.g. "BEGINNER", "NORMAL", "HYPER", "FOUR DIMENSIONS".
+    #[serde(default = "String::new")]
+    pub chart_name: String,
+    /// Self explanatory level number. It is usually set with subjective rating by the author.
+    pub level: u32,
+    /// Initial BPM.
+    pub init_bpm: FinF64,
+    /// Relative judge width in percentage. The variation amount may different by BMS player. Larger is easier.
+    #[serde(default = "default_percentage")]
+    pub judge_rank: FinF64,
+    /// Relative life bar gain in percentage. The variation amount may different by BMS player. Larger is easier.
+    #[serde(default = "default_percentage")]
+    pub total: FinF64,
+    /// Background image file name. This should be displayed during the game play.
+    pub back_image: Option<String>,
+    /// Eyecatch image file name. This should be displayed during the chart is loading.
+    pub eyecatch_image: Option<String>,
+    /// Title image file name. This should be displayed before the game starts instead of title of the music.
+    pub title_image: Option<String>,
+    /// Banner image file name. This should be displayed in music select or result scene. The aspect ratio of image is usually 15:4.
+    pub banner_image: Option<String>,
+    /// Preview music file name. This should be played when this chart is selected in a music select scene.
+    pub preview_music: Option<String>,
+    /// Numbers of pulse per quarter note in 4/4 measure. You must check this because it affects the actual seconds of `PulseNumber`.
+    #[serde(default = "default_resolution")]
+    pub resolution: u32,
+}
+
+/// Default mode hint, beatmania 7 keys.
+pub fn default_mode_hint() -> String {
+    "beat-7k".into()
+}
+
+/// Default relative percentage, 100%.
+pub fn default_percentage() -> FinF64 {
+    FinF64::new(100.0).unwrap()
+}
+
+/// Default resolution pulses per quarter note in 4/4 measure, 240 pulses.
+pub fn default_resolution() -> u32 {
+    240
+}
+
+/// Event of bar line of the chart.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BarLine {
+    /// Pulse number to place the line.
+    pub y: PulseNumber,
+}
+
+/// Note sound file and positions to be placed in the chart.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SoundChannel {
+    /// Sound file path. If the extension is not specified or not supported, you can try search files about other extensions for fallback.
+    pub name: String,
+    /// Data of note to be placed.
+    pub notes: Vec<Note>,
+}
+
+/// Sound note to ring a sound file.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Note {
+    /// Lane information. The `Some` number represents the key to play, otherwise it is not playable (BGM) note.
+    pub x: Option<NonZeroU8>,
+    /// Position to be placed.
+    pub y: PulseNumber,
+    /// Length of pulses of the note. It will be a normal note if zero, otherwise a long note.
+    pub l: u32,
+    /// Continuation flag. It will continue to ring rest of the file when play if `true`, otherwise it will play from start.
+    pub c: bool,
+}
+
+/// BPM change note.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BpmEvent {
+    /// Position to change BPM of the chart.
+    pub y: PulseNumber,
+    /// New BPM to be.
+    pub bpm: FinF64,
+}
+
+/// Scroll stop note.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StopEvent {
+    /// Start position to scroll stop.
+    pub y: PulseNumber,
+    /// Stopping duration in pulses.
+    pub duration: u32,
+}
+
+/// BGA data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Bga {
+    /// Pictures data for playing BGA.
+    pub bga_header: Vec<BgaHeader>,
+    /// Base picture sequence.
+    pub bga_events: Vec<BgaEvent>,
+    /// Layered picture sequence.
+    pub layer_events: Vec<BgaEvent>,
+    /// Picture sequence displayed when missed.
+    pub poor_events: Vec<BgaEvent>,
+}
+
+/// Picture file information.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BgaHeader {
+    /// Self explanatory ID of picture.
+    pub id: BgaId,
+    /// Picture file name.
+    pub name: String,
+}
+
+/// BGA note to display the picture.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BgaEvent {
+    /// Position to display the picture in pulses.
+    pub y: PulseNumber,
+    /// ID of picture to display.
+    pub id: BgaId,
+}
+
+/// Picture id for [`Bga`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct BgaId(pub u32);
+
+/// Errors on converting from `Bms` into `Bmson`.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BmsonConvertError {
+    /// The initial BPM was infinity or NaN.
+    #[error("header bpm was invalid value")]
+    InvalidBpm,
+    /// The total percentage was infinity or NaN.
+    #[error("header total was invalid value")]
+    InvalidTotal,
+}
+
+impl TryFrom<Bms> for Bmson {
+    type Error = BmsonConvertError;
+
+    fn try_from(value: Bms) -> Result<Self, Self::Error> {
+        let converter = PulseConverter::new(&value.notes);
+
+        let has_7keys = value
+            .notes
+            .all_notes()
+            .any(|note| note.key.is_extended_key());
+
+        const EASY_WIDTH: f64 = 21.0;
+        const NORMAL_WIDTH: f64 = 18.0;
+        const HARD_WIDTH: f64 = 15.0;
+        const VERY_HARD_WIDTH: f64 = 8.0;
+        let judge_rank = FinF64::new(match value.header.rank {
+            Some(JudgeLevel::Easy) => EASY_WIDTH / NORMAL_WIDTH,
+            Some(JudgeLevel::Normal) | None => 1.0,
+            Some(JudgeLevel::Hard) => HARD_WIDTH / NORMAL_WIDTH,
+            Some(JudgeLevel::VeryHard) => VERY_HARD_WIDTH / NORMAL_WIDTH,
+        })
+        .unwrap();
+
+        let resolution = value.notes.resolution_for_pulses();
+
+        let last_obj_time = value
+            .notes
+            .last_obj_time()
+            .unwrap_or_else(|| ObjTime::new(0, 0, 4));
+        let lines = (0..=last_obj_time.track.0)
+            .map(|track| BarLine {
+                y: converter.get_pulses_on(Track(track)),
+            })
+            .collect();
+
+        let bpm_events = value
+            .notes
+            .bpm_changes()
+            .values()
+            .map(|bpm_change| {
+                Ok(BpmEvent {
+                    y: converter.get_pulses_at(bpm_change.time),
+                    bpm: FinF64::new(bpm_change.bpm).ok_or(BmsonConvertError::InvalidBpm)?,
+                })
+            })
+            .collect::<Result<Vec<_>, BmsonConvertError>>()?;
+
+        let stop_events = value
+            .notes
+            .stops()
+            .values()
+            .map(|stop| StopEvent {
+                y: converter.get_pulses_at(stop.time),
+                duration: stop.duration,
+            })
+            .collect();
+
+        let info = BmsonInfo {
+            title: value.header.title.unwrap_or_default(),
+            subtitle: value.header.subtitle.unwrap_or_default(),
+            artist: value.header.artist.unwrap_or_default(),
+            subartists: vec![value.header.sub_artist.unwrap_or_default()],
+            genre: value.header.genre.unwrap_or_default(),
+            mode_hint: if has_7keys {
+                "beat-7k".into()
+            } else {
+                "beat-5k".into()
+            },
+            chart_name: "".into(),
+            level: value.header.play_level.unwrap_or_default() as u32,
+            init_bpm: FinF64::new(value.header.bpm.unwrap_or(120.0))
+                .ok_or(BmsonConvertError::InvalidBpm)?,
+            judge_rank,
+            total: FinF64::new(value.header.total.unwrap_or(100.0))
+                .ok_or(BmsonConvertError::InvalidTotal)?,
+            back_image: value
+                .header
+                .back_bmp
+                .as_ref()
+                .cloned()
+                .map(|path| path.display().to_string()),
+            eyecatch_image: value
+                .header
+                .stage_file
+                .map(|path| path.display().to_string()),
+            title_image: value.header.back_bmp.map(|path| path.display().to_string()),
+            banner_image: value.header.banner.map(|path| path.display().to_string()),
+            preview_music: None,
+            resolution,
+        };
+
+        let sound_channels = {
+            let path_root = value.header.wav_path_root.unwrap_or_default();
+            let mut sound_channels = HashMap::new();
+            for note in value.notes.all_notes() {
+                let note_lane = note.kind.is_playable().then(|| match note.key {
+                    Key::Key1 => 1,
+                    Key::Key2 => 2,
+                    Key::Key3 => 3,
+                    Key::Key4 => 4,
+                    Key::Key5 => 5,
+                    Key::Key6 => 6,
+                    Key::Key7 => 7,
+                    Key::Scratch | Key::FreeZone => 8,
+                } + if note.is_player1 {0} else {8}).map(|num| NonZeroU8::new(num).unwrap());
+                let pulses = converter.get_pulses_at(note.offset);
+                let duration =
+                    if let Some(next_note) = value.notes.next_obj_by_key(note.key, note.offset) {
+                        pulses.abs_diff(converter.get_pulses_at(next_note.offset))
+                    } else {
+                        0
+                    };
+                let to_insert = Note {
+                    x: note_lane,
+                    y: pulses,
+                    l: duration,
+                    c: false,
+                };
+
+                sound_channels
+                    .entry(note.obj)
+                    .and_modify(|channel: &mut SoundChannel| channel.notes.push(to_insert.clone()))
+                    .or_insert_with(|| {
+                        let sound_path = path_root.join(
+                            value
+                                .header
+                                .wav_files
+                                .get(&note.obj)
+                                .cloned()
+                                .unwrap_or_default(),
+                        );
+                        SoundChannel {
+                            name: sound_path.display().to_string(),
+                            notes: vec![to_insert],
+                        }
+                    });
+            }
+            sound_channels.into_values().collect()
+        };
+
+        let bga = {
+            let mut bga = Bga {
+                bga_header: vec![],
+                bga_events: vec![],
+                layer_events: vec![],
+                poor_events: vec![],
+            };
+            for (id, bmp) in &value.header.bmp_files {
+                bga.bga_header.push(BgaHeader {
+                    id: BgaId(id.0.get() as u32),
+                    name: bmp.file.display().to_string(),
+                });
+            }
+            for (&time, change) in value.notes.bga_changes() {
+                let target = match change.layer {
+                    BgaLayer::Base => &mut bga.bga_events,
+                    BgaLayer::Poor => &mut bga.poor_events,
+                    BgaLayer::Overlay => &mut bga.layer_events,
+                };
+                target.push(BgaEvent {
+                    y: converter.get_pulses_at(time),
+                    id: BgaId(change.id.0.get() as u32),
+                })
+            }
+            bga
+        };
+
+        Ok(Self {
+            version: "1.0.0".into(),
+            info,
+            lines: Some(lines),
+            bpm_events,
+            stop_events,
+            sound_channels,
+            bga,
+        })
+    }
+}

--- a/src/bmson/fin_f64.rs
+++ b/src/bmson/fin_f64.rs
@@ -1,0 +1,45 @@
+//! Finite binary64 definition.
+
+use serde::{Deserialize, Serialize};
+
+/// `f64` but it has only finite value.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct FinF64(f64);
+
+impl Eq for FinF64 {}
+impl Ord for FinF64 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.total_cmp(&other.0)
+    }
+}
+
+impl From<FinF64> for f64 {
+    fn from(value: FinF64) -> Self {
+        value.as_f64()
+    }
+}
+
+impl FinF64 {
+    /// Creates a new `FinF64` from `f64` if `float` is finite, otherwise returns `None`.
+    #[inline]
+    pub fn new(float: f64) -> Option<Self> {
+        if float.is_finite() {
+            Some(Self(float))
+        } else {
+            None
+        }
+    }
+
+    /// Gets the internal value.
+    #[inline]
+    pub fn as_f64(self) -> f64 {
+        self.0
+    }
+
+    /// Gets a reference to the internal value.
+    #[inline]
+    pub fn as_ref(&self) -> &f64 {
+        &self.0
+    }
+}

--- a/src/bmson/pulse.rs
+++ b/src/bmson/pulse.rs
@@ -1,0 +1,181 @@
+//! Pulse definition for bmson format. It represents only beat on the score, so you need to know previous BPMs for finding happening seconds of a note.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    parse::notes::Notes,
+    time::{ObjTime, Track},
+};
+
+/// Note position for the chart [`Bmson`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct PulseNumber(pub u32);
+
+/// Converter from [`ObjTime`] into pulses, which split one quarter note evenly.
+#[derive(Debug, Clone)]
+pub struct PulseConverter {
+    pulses_at_track_start: BTreeMap<Track, u32>,
+    resolution: u32,
+}
+
+impl PulseConverter {
+    /// Creates a new converter from [`Notes`].
+    pub fn new(notes: &Notes) -> Self {
+        let resolution = notes.resolution_for_pulses();
+        let mut pulses_at_track_start = BTreeMap::new();
+        let mut current_track = 0;
+        let mut current_pulses = 0;
+        for (track, section_len_change) in notes.section_len_changes() {
+            while current_track < track.0 {
+                pulses_at_track_start.insert(Track(current_track), current_pulses);
+                current_pulses += resolution;
+                current_track += 1;
+            }
+
+            debug_assert_eq!(current_track, track.0);
+            pulses_at_track_start.insert(Track(current_track), current_pulses);
+            current_pulses += (section_len_change.length * 4.0 * resolution as f64) as u32;
+        }
+        Self {
+            pulses_at_track_start,
+            resolution,
+        }
+    }
+
+    /// Gets pulses on the start of [`Track`].
+    pub fn get_pulses_on(&self, track: Track) -> PulseNumber {
+        PulseNumber(
+            self.pulses_at_track_start
+                .get(&track)
+                .copied()
+                .or_else(|| {
+                    self.pulses_at_track_start
+                        .last_key_value()
+                        .map(|(_, &pulses)| pulses)
+                })
+                .unwrap_or_default(),
+        )
+    }
+
+    /// Gets pulses at the [`ObjTime`].
+    pub fn get_pulses_at(&self, time: ObjTime) -> PulseNumber {
+        let PulseNumber(track_base) = self.get_pulses_on(time.track);
+        PulseNumber(
+            track_base
+                + (self.resolution as f64 * time.numerator as f64 / time.denominator as f64) as u32,
+        )
+    }
+}
+
+#[test]
+fn pulse_conversion() {
+    use crate::{
+        lex::command::{Key, NoteKind},
+        parse::{notes::SectionLenChangeObj, obj::Obj},
+    };
+
+    // Source BMS:
+    // ```
+    // #00102:0.75
+    // #00103:1.25
+    // ```
+    let notes = {
+        let mut notes = Notes::default();
+        notes.push_section_len_change(SectionLenChangeObj {
+            track: Track(1),
+            length: 0.75,
+        });
+        notes.push_section_len_change(SectionLenChangeObj {
+            track: Track(2),
+            length: 1.25,
+        });
+        notes.push_note(Obj {
+            offset: ObjTime {
+                track: Track(1),
+                numerator: 2,
+                denominator: 3,
+            },
+            kind: NoteKind::Visible,
+            is_player1: true,
+            key: Key::Key1,
+            obj: 1.try_into().unwrap(),
+        });
+        notes
+    };
+    let converter = PulseConverter::new(&notes);
+
+    assert_eq!(converter.resolution, 2);
+
+    assert_eq!(
+        converter
+            .get_pulses_at(ObjTime {
+                track: Track(0),
+                numerator: 0,
+                denominator: 4
+            })
+            .0,
+        0
+    );
+    assert_eq!(
+        converter
+            .get_pulses_at(ObjTime {
+                track: Track(0),
+                numerator: 2,
+                denominator: 4
+            })
+            .0,
+        4
+    );
+    assert_eq!(
+        converter
+            .get_pulses_at(ObjTime {
+                track: Track(1),
+                numerator: 0,
+                denominator: 4
+            })
+            .0,
+        8
+    );
+    assert_eq!(
+        converter
+            .get_pulses_at(ObjTime {
+                track: Track(1),
+                numerator: 2,
+                denominator: 4
+            })
+            .0,
+        11
+    );
+    assert_eq!(
+        converter
+            .get_pulses_at(ObjTime {
+                track: Track(2),
+                numerator: 0,
+                denominator: 4
+            })
+            .0,
+        14
+    );
+    assert_eq!(
+        converter
+            .get_pulses_at(ObjTime {
+                track: Track(2),
+                numerator: 2,
+                denominator: 4
+            })
+            .0,
+        19
+    );
+    assert_eq!(
+        converter
+            .get_pulses_at(ObjTime {
+                track: Track(3),
+                numerator: 0,
+                denominator: 4
+            })
+            .0,
+        24
+    );
+}

--- a/src/bmson/pulse.rs
+++ b/src/bmson/pulse.rs
@@ -75,7 +75,8 @@ impl PulseConverter {
         let PulseNumber(track_base) = self.get_pulses_on(time.track);
         PulseNumber(
             track_base
-                + (self.resolution as f64 * time.numerator as f64 / time.denominator as f64) as u32,
+                + ((4 * self.resolution) as f64 * time.numerator as f64 / time.denominator as f64)
+                    as u32,
         )
     }
 }
@@ -123,27 +124,27 @@ fn pulse_conversion() {
                 denominator: 4
             })
             .0,
+        2
+    );
+    assert_eq!(
+        converter
+            .get_pulses_at(ObjTime {
+                track: Track(1),
+                numerator: 0,
+                denominator: 4
+            })
+            .0,
         4
     );
     assert_eq!(
         converter
             .get_pulses_at(ObjTime {
                 track: Track(1),
-                numerator: 0,
-                denominator: 4
-            })
-            .0,
-        8
-    );
-    assert_eq!(
-        converter
-            .get_pulses_at(ObjTime {
-                track: Track(1),
                 numerator: 2,
                 denominator: 4
             })
             .0,
-        11
+        6
     );
     assert_eq!(
         converter
@@ -153,7 +154,7 @@ fn pulse_conversion() {
                 denominator: 4
             })
             .0,
-        14
+        7
     );
     assert_eq!(
         converter
@@ -163,7 +164,7 @@ fn pulse_conversion() {
                 denominator: 4
             })
             .0,
-        19
+        9
     );
     assert_eq!(
         converter
@@ -173,6 +174,6 @@ fn pulse_conversion() {
                 denominator: 4
             })
             .0,
-        24
+        12
     );
 }

--- a/src/bmson/pulse.rs
+++ b/src/bmson/pulse.rs
@@ -13,6 +13,13 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PulseNumber(pub u32);
 
+impl PulseNumber {
+    /// Calculates an absolute difference of two pulses.
+    pub const fn abs_diff(self, other: Self) -> u32 {
+        self.0.abs_diff(other.0)
+    }
+}
+
 /// Converter from [`ObjTime`] into pulses, which split one quarter note evenly.
 #[derive(Debug, Clone)]
 pub struct PulseConverter {

--- a/src/lex/command.rs
+++ b/src/lex/command.rs
@@ -143,6 +143,13 @@ pub enum NoteKind {
     Landmine,
 }
 
+impl NoteKind {
+    /// Returns whether the note is visible.
+    pub const fn is_visible(self) -> bool {
+        !matches!(self, Self::Invisible)
+    }
+}
+
 /// A key of the controller or keyboard.
 ///
 /// ```text
@@ -175,6 +182,11 @@ pub enum Key {
 }
 
 impl Key {
+    /// Returns whether the key appears only 7 keys.
+    pub fn is_extended_key(self) -> bool {
+        matches!(self, Self::Key6 | Self::Key7)
+    }
+
     pub(crate) fn from(key: &str, c: &mut Cursor) -> Result<Self> {
         use Key::*;
         Ok(match key {

--- a/src/lex/command.rs
+++ b/src/lex/command.rs
@@ -317,5 +317,5 @@ impl Channel {
 }
 
 /// A track, or bar, in the score. It must greater than 0, but some scores may include the 0 track.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Track(pub u32);

--- a/src/lex/command.rs
+++ b/src/lex/command.rs
@@ -144,9 +144,14 @@ pub enum NoteKind {
 }
 
 impl NoteKind {
-    /// Returns whether the note is visible.
-    pub const fn is_visible(self) -> bool {
+    /// Returns whether the note is a playable.
+    pub const fn is_playable(self) -> bool {
         !matches!(self, Self::Invisible)
+    }
+
+    /// Returns whether the note is a long-press note.
+    pub const fn is_long(self) -> bool {
+        matches!(self, Self::Long)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,11 @@
 #![warn(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+#[cfg(feature = "bmson")]
+pub mod bmson;
 pub mod lex;
 pub mod parse;
+pub mod time;
 
 use self::{lex::LexError, parse::ParseError};
 

--- a/src/parse/header.rs
+++ b/src/parse/header.rs
@@ -99,6 +99,8 @@ pub struct Header {
     pub texts: HashMap<ObjId, String>,
     /// The option messages corresponding to the id of the change option object.
     pub change_options: HashMap<ObjId, String>,
+    /// Stop lengths by stop object id.
+    pub stops: HashMap<ObjId, u32>,
 }
 
 impl Header {
@@ -210,6 +212,12 @@ impl Header {
             Token::PoorBga(poor_bga_mode) => self.poor_bga_mode = poor_bga_mode,
             Token::Rank(rank) => self.rank = Some(rank),
             Token::StageFile(file) => self.stage_file = Some(file.into()),
+            Token::Stop(id, len) => {
+                self.stops
+                    .entry(id)
+                    .and_modify(|current_len| *current_len += len)
+                    .or_insert(len);
+            }
             Token::SubArtist(sub_artist) => self.sub_artist = Some(sub_artist.into()),
             Token::SubTitle(subtitle) => self.subtitle = Some(subtitle.into()),
             Token::Text(id, text) => {

--- a/src/parse/notes.rs
+++ b/src/parse/notes.rs
@@ -455,7 +455,7 @@ impl Notes {
         for bpm_change in self.bpm_changes.values() {
             hyp_resolution = hyp_resolution.lcm(&bpm_change.time.denominator);
         }
-        hyp_resolution / 4
+        hyp_resolution
     }
 }
 

--- a/src/parse/notes.rs
+++ b/src/parse/notes.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use std::{
     cmp::Reverse,
     collections::{BTreeMap, HashMap},
+    ops::Bound,
 };
 
 use super::{header::Header, obj::Obj, ParseError, Result};
@@ -152,6 +153,15 @@ impl Notes {
     /// Returns the scroll stop objects.
     pub fn stops(&self) -> &BTreeMap<ObjTime, StopObj> {
         &self.stops
+    }
+
+    /// Finds next object on the key `Key` from the time `ObjTime`.
+    pub fn next_obj_by_key(&self, key: Key, time: ObjTime) -> Option<&Obj> {
+        self.ids_by_key
+            .get(&key)?
+            .range((Bound::Excluded(time), Bound::Unbounded))
+            .next()
+            .and_then(|(_, id)| self.objs.get(id))
     }
 
     /// Adds the new note object to the notes.

--- a/src/parse/obj.rs
+++ b/src/parse/obj.rs
@@ -1,59 +1,9 @@
 //! Definitions of the note object.
 
-use crate::lex::command::{Key, NoteKind, ObjId};
-
-/// A track, or measure, where the object is in.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Track(pub u32);
-
-/// A time of the object on the score.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ObjTime {
-    /// The track, or measure, where the object is in.
-    pub track: Track,
-    /// The time offset numerator in the track.
-    pub numerator: u32,
-    /// The time offset denominator in the track.
-    pub denominator: u32,
-}
-
-impl ObjTime {
-    /// Create a new time.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `denominator` is 0 or `numerator` is greater than or equal to `denominator`.
-    pub fn new(track: u32, numerator: u32, denominator: u32) -> Self {
-        if track == 0 {
-            eprintln!("warning: track 000 detected");
-        }
-        assert!(0 < denominator);
-        assert!(numerator < denominator);
-        Self {
-            track: Track(track),
-            numerator,
-            denominator,
-        }
-    }
-}
-
-impl PartialOrd for ObjTime {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for ObjTime {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let self_time_in_track = self.numerator * other.denominator;
-        let other_time_in_track = other.numerator * self.denominator;
-        self.track
-            .cmp(&other.track)
-            .then(self_time_in_track.cmp(&other_time_in_track))
-    }
-}
+use crate::{
+    lex::command::{Key, NoteKind, ObjId},
+    time::ObjTime,
+};
 
 /// An object on the score.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,54 @@
+//! Definitions of time in BMS.
+
+/// A track, or measure, where the object is in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Track(pub u32);
+
+/// A time of the object on the score.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ObjTime {
+    /// The track, or measure, where the object is in.
+    pub track: Track,
+    /// The time offset numerator in the track.
+    pub numerator: u32,
+    /// The time offset denominator in the track.
+    pub denominator: u32,
+}
+
+impl ObjTime {
+    /// Create a new time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `denominator` is 0 or `numerator` is greater than or equal to `denominator`.
+    pub fn new(track: u32, numerator: u32, denominator: u32) -> Self {
+        if track == 0 {
+            eprintln!("warning: track 000 detected");
+        }
+        assert!(0 < denominator);
+        assert!(numerator < denominator);
+        Self {
+            track: Track(track),
+            numerator,
+            denominator,
+        }
+    }
+}
+
+impl PartialOrd for ObjTime {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ObjTime {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let self_time_in_track = self.numerator * other.denominator;
+        let other_time_in_track = other.numerator * self.denominator;
+        self.track
+            .cmp(&other.track)
+            .then(self_time_in_track.cmp(&other_time_in_track))
+    }
+}

--- a/tests/nested_random.rs
+++ b/tests/nested_random.rs
@@ -3,11 +3,8 @@ use bms_rs::{
         command::{Key, NoteKind},
         parse,
     },
-    parse::{
-        obj::{Obj, ObjTime},
-        rng::RngMock,
-        Bms,
-    },
+    parse::{obj::Obj, rng::RngMock, Bms},
+    time::ObjTime,
 };
 
 #[test]


### PR DESCRIPTION
- Add bmson feature
- Add match helper
- Add stops
- Support stops and pulses
- Split ObjTime into time module
- Add bmson and time module
- Refactor with ids_from_message
- Track derive some traits
- Add FinF64
- Add PulseNumber
- Improve NoteKind helper
- Add next_obj_by_key
- Add abs_diff
- Add BGA data for Notes
- Fix to store ObjId instead of PathBuf
- Add Bmson
- Stop to divide by 4
- Fix last_obj_time
- Fix constructor
- Fix get_pulses_at
- Fix import
