### PR TITLE
Fix Bgm Obj can't be fully parsed

### DIFF
--- a/src/parse/notes.rs
+++ b/src/parse/notes.rs
@@ -386,10 +386,7 @@ impl Notes {
                 message,
             } => {
                 for (time, obj) in ids_from_message(*track, message) {
-                    self.bgms
-                        .entry(time)
-                        .and_modify(|vec| vec.push(obj))
-                        .or_insert_with(Vec::new);
+                    self.bgms.entry(time).or_default().push(obj)
                 }
             }
             Token::Message {


### PR DESCRIPTION
Before Fix:
![image](https://github.com/MikuroXina/bms-rs/assets/77726985/77b2e65f-7df7-4a86-959e-ebcf959a4dea)

After Fix:
![image](https://github.com/MikuroXina/bms-rs/assets/77726985/c5827188-569f-4757-8a77-250901815642)
