### PR TITLE
Fix non-standard resource name can't be handled correctly.

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -11,7 +11,7 @@ use self::{
 
 /// An error occurred when lexical analysis.
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LexError {
     /// An unknown command detected.
     UnknownCommand {
@@ -47,7 +47,6 @@ impl std::fmt::Display for LexError {
 }
 
 impl std::error::Error for LexError {}
-
 /// An error occurred when lexical analyzing the BMS format file.
 pub type Result<T> = std::result::Result<T, LexError>;
 

--- a/src/lex/cursor.rs
+++ b/src/lex/cursor.rs
@@ -67,11 +67,14 @@ impl<'a> Cursor<'a> {
     }
 
     pub(crate) fn next_line_remaining(&mut self) -> &'a str {
+        fn is_blank_or_tab(c: char) -> bool {
+            return c == ' ' || c == '\t';
+        }
         let spaces = self.source[self.index..]
-            .find(|c: char| !c.is_whitespace())
+            .find(|c: char| !is_blank_or_tab(c))
             .unwrap_or(self.source.len());
 
-        self.col += spaces;
+        self.col += 1;
         self.index += spaces;
 
         let remaining_end = self.source[self.index..]

--- a/src/lex/cursor.rs
+++ b/src/lex/cursor.rs
@@ -67,16 +67,6 @@ impl<'a> Cursor<'a> {
     }
 
     pub(crate) fn next_line_remaining(&mut self) -> &'a str {
-        fn is_blank_or_tab(c: char) -> bool {
-            return c == ' ' || c == '\t';
-        }
-        let spaces = self.source[self.index..]
-            .find(|c: char| !is_blank_or_tab(c))
-            .unwrap_or(self.source.len());
-
-        self.col += 1;
-        self.index += spaces;
-
         let remaining_end = self.source[self.index..]
             .find('\n')
             .unwrap_or(self.source.len());
@@ -91,7 +81,7 @@ impl<'a> Cursor<'a> {
         };
         self.col += ret.chars().count();
         self.index += remaining_end;
-        ret
+        ret.trim()
     }
 
     pub(crate) fn line(&self) -> usize {

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -241,16 +241,20 @@ impl<'a> Token<'a> {
                 }
                 wav if wav.starts_with("#WAV") => {
                     let id = command.trim_start_matches("#WAV");
+                    let str = c.next_line_remaining();
                     let filename = Path::new(
-                        c.next_token()
+                        (!(str.is_empty()))
+                            .then(|| str)
                             .ok_or_else(|| c.err_expected_token("key audio filename"))?,
                     );
                     Self::Wav(ObjId::from(id, c)?, filename)
                 }
                 bmp if bmp.starts_with("#BMP") => {
                     let id = command.trim_start_matches("#BMP");
+                    let str = c.next_line_remaining();
                     let filename = Path::new(
-                        c.next_token()
+                        (!str.is_empty())
+                            .then(|| str)
                             .ok_or_else(|| c.err_expected_token("bgi image filename"))?,
                     );
                     if id == "00" {

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -242,21 +242,19 @@ impl<'a> Token<'a> {
                 wav if wav.starts_with("#WAV") => {
                     let id = command.trim_start_matches("#WAV");
                     let str = c.next_line_remaining();
-                    let filename = Path::new(
-                        (!(str.is_empty()))
-                            .then(|| str)
-                            .ok_or_else(|| c.err_expected_token("key audio filename"))?,
-                    );
+                    if str.is_empty() {
+                        return Err(c.err_expected_token("key audio filename"));
+                    }
+                    let filename = Path::new(str);
                     Self::Wav(ObjId::from(id, c)?, filename)
                 }
                 bmp if bmp.starts_with("#BMP") => {
                     let id = command.trim_start_matches("#BMP");
                     let str = c.next_line_remaining();
-                    let filename = Path::new(
-                        (!str.is_empty())
-                            .then(|| str)
-                            .ok_or_else(|| c.err_expected_token("bgi image filename"))?,
-                    );
+                    if str.is_empty() {
+                        return Err(c.err_expected_token("key audio filename"));
+                    }
+                    let filename = Path::new(str);
                     if id == "00" {
                         Self::Bmp(None, filename)
                     } else {

--- a/tests/dive_withblank.bme
+++ b/tests/dive_withblank.bme
@@ -12,14 +12,14 @@
 #STAGEFILE _title.bmp
 
 *WAV with blank
-#WAV1O Cymbals Crash 05.wav
+#WAV1O	Cymbals	Crash 05.wav
 #WAV1P Cymbals Crash 10.wav
 #WAV1Q Cymbals Crash 10_240.wav
 #WAV1R Cymbals Crash 10_480.wav
-#WAV1S Cymbals Ride 05.wav
+#WAV1S 
 
 *Blank BMP
-#BMP01 
+#BMP01
 
 *---------------------- MAIN DATA FIELD
 

--- a/tests/dive_withblank.bme
+++ b/tests/dive_withblank.bme
@@ -1,0 +1,28 @@
+
+*---------------------- HEADER FIELD
+
+#PLAYER 1
+#GENRE HAPPY HARDCORE
+#TITLE FREEDOM DiVE [Test]
+#ARTIST xi / obj: kznr
+#BPM 222.22
+#PLAYLEVEL 1
+#RANK 3
+#TOTAL 500
+#STAGEFILE _title.bmp
+
+*WAV with blank
+#WAV1O Cymbals Crash 05.wav
+#WAV1P Cymbals Crash 10.wav
+#WAV1Q Cymbals Crash 10_240.wav
+#WAV1R Cymbals Crash 10_480.wav
+#WAV1S Cymbals Ride 05.wav
+
+*Blank BMP
+#BMP01 
+
+*---------------------- MAIN DATA FIELD
+
+
+
+#00116:0000001O000000000000000000000000

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -1,6 +1,6 @@
 use bms_rs::{
     lex::{parse, LexError},
-    parse::{rng::RngMock, Bms, ParseError},
+    parse::{rng::RngMock, Bms},
 };
 
 #[test]
@@ -31,5 +31,12 @@ fn test_j219() {
 fn test_blank() {
     let source = include_str!("dive_withblank.bme");
     let ts = parse(source);
-    assert_eq!(ts.is_err(), true);
+    assert_eq!(
+        ts.err(),
+        Some(LexError::ExpectedToken {
+            line: 19,
+            col: 8,
+            message: "key audio filename"
+        })
+    );
 }

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -1,6 +1,6 @@
 use bms_rs::{
-    lex::parse,
-    parse::{rng::RngMock, Bms},
+    lex::{parse, LexError},
+    parse::{rng::RngMock, Bms, ParseError},
 };
 
 #[test]
@@ -25,4 +25,11 @@ fn test_j219() {
     let ts = parse(source).expect("must be parsed");
     let bms = Bms::from_token_stream(&ts, RngMock([1])).expect("must be parsed");
     eprintln!("{:?}", bms);
+}
+
+#[test]
+fn test_blank() {
+    let source = include_str!("dive_withblank.bme");
+    let ts = parse(source);
+    assert_eq!(ts.is_err(), true);
 }


### PR DESCRIPTION
1. Fix the wav file with blank space can't be fully parse. (Freedom Dive)
2. Incorrect resource file won't be parsed. (#WAV/#BMP filename which is without prefix/extension or just a blank name)