### PR TITLE
fix(bms/lex): use Cow<'a, str>, for performance?

### DIFF
--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -398,7 +398,9 @@ impl<'a> Token<'a> {
                 id.make_uppercase();
             }
             Message { message, .. } => {
-                message.make_ascii_uppercase();
+                if message.chars().any(|ch| ch.is_ascii_lowercase()) {
+                    message.to_mut().make_ascii_uppercase();
+                }
             }
             Scroll(id, _) => {
                 id.make_uppercase();
@@ -417,34 +419,6 @@ impl<'a> Token<'a> {
             }
             _ => {}
         }
-    }
-}
-
-trait CowStr {
-    fn make_ascii_uppercase(&mut self);
-}
-
-impl CowStr for Cow<'_, str> {
-    fn make_ascii_uppercase(&mut self) {
-        let Some((first_lower_index, _)) = self
-            .as_bytes()
-            .iter()
-            .enumerate()
-            .find(|(_, byte)| byte.is_ascii_lowercase())
-        else {
-            return;
-        };
-        *self = Cow::Owned(unsafe {
-            let mut string = self.to_string();
-            string
-                .as_bytes_mut()
-                .iter_mut()
-                .skip(first_lower_index)
-                .for_each(|byte| {
-                    *byte = byte.to_ascii_uppercase();
-                });
-            string
-        });
     }
 }
 

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -1,6 +1,6 @@
 //! Definitions of the token in BMS format.
 
-use std::path::Path;
+use std::{borrow::Cow, path::Path};
 
 use super::{command::*, cursor::Cursor, Result};
 
@@ -112,7 +112,7 @@ pub enum Token<'a> {
         /// The channel commonly expresses what the lane be arranged the note to.
         channel: Channel,
         /// The message to the channel.
-        message: String,
+        message: Cow<'a, str>,
     },
     /// `#MIDIFILE [filename]`. Defines the MIDI file as the BGM. *Deprecated*
     MidiFile(&'a Path),
@@ -350,7 +350,7 @@ impl<'a> Token<'a> {
                     Self::Message {
                         track: Track(track),
                         channel: Channel::from(channel, c)?,
-                        message: message.to_owned(),
+                        message: Cow::Borrowed(message),
                     }
                 }
                 comment if !comment.starts_with('#') => {
@@ -398,7 +398,7 @@ impl<'a> Token<'a> {
                 id.make_uppercase();
             }
             Message { message, .. } => {
-                message.make_ascii_uppercase();
+                *message = Cow::Owned(message.to_ascii_uppercase());
             }
             Scroll(id, _) => {
                 id.make_uppercase();

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -398,7 +398,7 @@ impl<'a> Token<'a> {
                 id.make_uppercase();
             }
             Message { message, .. } => {
-                *message = Cow::Owned(message.to_ascii_uppercase());
+                message.make_ascii_uppercase();
             }
             Scroll(id, _) => {
                 id.make_uppercase();
@@ -417,6 +417,34 @@ impl<'a> Token<'a> {
             }
             _ => {}
         }
+    }
+}
+
+trait CowStr {
+    fn make_ascii_uppercase(&mut self);
+}
+
+impl CowStr for Cow<'_, str> {
+    fn make_ascii_uppercase(&mut self) {
+        let Some((first_lower_index, _)) = self
+            .as_bytes()
+            .iter()
+            .enumerate()
+            .find(|(_, byte)| byte.is_ascii_lowercase())
+        else {
+            return;
+        };
+        *self = Cow::Owned(unsafe {
+            let mut string = self.to_string();
+            string
+                .as_bytes_mut()
+                .iter_mut()
+                .skip(first_lower_index)
+                .for_each(|byte| {
+                    *byte = byte.to_ascii_uppercase();
+                });
+            string
+        });
     }
 }
 

--- a/tests/base_62.rs
+++ b/tests/base_62.rs
@@ -15,6 +15,10 @@ fn test_not_base_62() {
     let bms = Bms::from_token_stream(&ts, RngMock([1])).expect("must be parsed");
     eprintln!("{:?}", bms);
     assert_eq!(bms.header.wav_files.len(), 1);
+    assert_eq!(
+        bms.header.wav_files.iter().next().unwrap().1,
+        &std::path::Path::new("fuga.wav").to_path_buf()
+    );
 }
 
 #[test]


### PR DESCRIPTION
The improvement I think is almost none.
But it may be a little useful when writing other part.
I create this because of the PR on #91, where changes `Token::Message.message` from `&'a str` to `String`.