### PR TITLE
fix: Minor pedantic fixes by cargo clippy

### DIFF
--- a/src/bms.rs
+++ b/src/bms.rs
@@ -75,7 +75,7 @@ pub enum BmsWarning {
 }
 
 /// Output of parsing a BMS file.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BmsOutput<T: KeyLayoutMapper = KeyLayoutBeat> {
     /// The parsed BMS data.

--- a/src/bms.rs
+++ b/src/bms.rs
@@ -77,6 +77,7 @@ pub enum BmsWarning {
 /// Output of parsing a BMS file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[must_use]
 pub struct BmsOutput<T: KeyLayoutMapper = KeyLayoutBeat> {
     /// The parsed BMS data.
     pub bms: Bms<T>,

--- a/src/bms/ast.rs
+++ b/src/bms/ast.rs
@@ -42,6 +42,7 @@ pub struct AstRoot<'a> {
 
 /// The output of building the AST.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub struct AstBuildOutput<'a> {
     /// The units of the AST.
     pub root: AstRoot<'a>,
@@ -65,6 +66,7 @@ impl<'a> AstRoot<'a> {
 
 /// The output of parsing the AST.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub struct AstParseOutput<'a> {
     /// The tokens that were parsed.
     pub token_refs: TokenRefStream<'a>,
@@ -86,6 +88,7 @@ impl<'a> AstRoot<'a> {
     /// This function flattens the AST structure and returns ALL tokens contained in the AST,
     /// including all branches in Random and Switch blocks. This serves as the inverse of
     /// [`AstRoot::from_token_stream`].
+    #[must_use]
     pub fn extract(self) -> TokenStream<'a> {
         let tokens = ast_extract::extract_units(self.units);
         TokenStream { tokens }

--- a/src/bms/ast.rs
+++ b/src/bms/ast.rs
@@ -84,7 +84,7 @@ impl<'a> AstRoot<'a> {
 }
 
 impl<'a> AstRoot<'a> {
-    /// Extracts all tokens from the AST and returns them as a TokenStream.
+    /// Extracts all tokens from the AST and returns them as a [`TokenStream`].
     /// This function flattens the AST structure and returns ALL tokens contained in the AST,
     /// including all branches in Random and Switch blocks. This serves as the inverse of
     /// [`AstRoot::from_token_stream`].

--- a/src/bms/ast/ast_build.rs
+++ b/src/bms/ast/ast_build.rs
@@ -16,7 +16,7 @@ use crate::bms::{
 
 use super::AstBuildWarning;
 
-/// The main entry for building the control flow AST. Traverses the TokenWithRange stream and recursively parses all control flow blocks.
+/// The main entry for building the control flow AST. Traverses the [`TokenWithRange`] stream and recursively parses all control flow blocks.
 /// Returns a list of AST nodes and collects all control flow related errors.
 pub(super) fn build_control_flow_ast<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     tokens_iter: &mut Peekable<T>,
@@ -52,7 +52,7 @@ pub(super) fn build_control_flow_ast<'a, T: Iterator<Item = &'a TokenWithRange<'
     (result, errors)
 }
 
-/// Handle a single TokenWithRange: if it is the start of a block, recursively call the block parser, otherwise return a TokenWithRange node.
+/// Handle a single [`TokenWithRange`]: if it is the start of a block, recursively call the block parser, otherwise return a [`TokenWithRange`] node.
 fn parse_unit_or_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     iter: &mut Peekable<T>,
 ) -> Option<(Unit<'a>, Vec<AstBuildWarningWithRange>)> {
@@ -75,8 +75,8 @@ fn parse_unit_or_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     }
 }
 
-/// Parse a Switch/SetSwitch block until EndSwitch or auto-completion termination.
-/// Supports Case/Def branches, error detection, and nested structures.
+/// Parse a [`Token::Switch`]/[`Token::SetSwitch`] block until [`Token::EndSwitch`] or auto-completion termination.
+/// Supports [`Token::Case`]/[`Token::Def`] branches, error detection, and nested structures.
 fn parse_switch_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     iter: &mut Peekable<T>,
 ) -> (Unit<'a>, Vec<AstBuildWarningWithRange>) {
@@ -214,8 +214,8 @@ fn parse_switch_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     )
 }
 
-/// Parse the body of a Case/Def branch until a branch-terminating TokenWithRange is encountered.
-/// Supports nested blocks, prioritizing parse_unit_or_block.
+/// Parse the body of a [`Token::Case`]/[`Token::Def`] branch until a branch-terminating [`TokenWithRange`] is encountered.
+/// Supports nested blocks, prioritizing [`parse_unit_or_block`].
 fn parse_case_or_def_body<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     iter: &mut Peekable<T>,
 ) -> (Vec<Unit<'a>>, Vec<AstBuildWarningWithRange>) {
@@ -249,12 +249,12 @@ fn parse_case_or_def_body<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     (result, errors)
 }
 
-/// Parse a Random/SetRandom block until EndRandom or auto-completion termination.
-/// Supports nesting, error detection, and auto-closes when encountering non-control-flow Tokens outside IfBlock.
+/// Parse a [`Token::Random`]/[`Token::SetRandom`] block until [`Token::EndRandom`] or auto-completion termination.
+/// Supports nesting, error detection, and auto-closes when encountering non-control-flow Tokens outside [`IfBlock`].
 /// Design:
-/// - After entering Random/SetRandom, loop through Tokens.
-/// - If encountering If/ElseIf/Else, collect branches and check for duplicates/out-of-range.
-/// - If encountering a non-control-flow TokenWithRange, prioritize parse_unit_or_block; if not in any IfBlock, auto-close the block.
+/// - After entering [`Token::Random`]/[`Token::SetRandom`], loop through Tokens.
+/// - If encountering [`Token::If`]/[`Token::ElseIf`]/[`Token::Else`], collect branches and check for duplicates/out-of-range.
+/// - If encountering a non-control-flow [`TokenWithRange`], prioritize [`parse_unit_or_block`]; if not in any [`IfBlock`], auto-close the block.
 /// - Supports nested structures; recursively handle other block types.
 fn parse_random_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     iter: &mut Peekable<T>,
@@ -435,11 +435,11 @@ fn parse_random_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     )
 }
 
-/// Parse the body of an If/ElseIf/Else branch until a branch-terminating TokenWithRange is encountered.
+/// Parse the body of an [`Token::If`]/[`Token::ElseIf`]/[`Token::Else`] branch until a branch-terminating [`TokenWithRange`] is encountered.
 /// Design:
-/// - Supports nested blocks, prioritizing parse_unit_or_block.
-/// - Break when encountering branch-terminating Tokens (ElseIf/Else/EndIf/EndRandom/EndSwitch).
-/// - If EndIf is encountered, consume it automatically.
+/// - Supports nested blocks, prioritizing [`parse_unit_or_block`].
+/// - Break when encountering branch-terminating Tokens ([`Token::ElseIf`]/[`Token::Else`]/[`Token::EndIf`]/[`Token::EndRandom`]/[`Token::EndSwitch`]).
+/// - If [`Token::EndIf`] is encountered, consume it automatically.
 fn parse_if_block_body<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     iter: &mut Peekable<T>,
     default_end_pos: SourceRangeMixin<()>,

--- a/src/bms/ast/ast_build.rs
+++ b/src/bms/ast/ast_build.rs
@@ -470,7 +470,7 @@ fn parse_if_block_body<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
         if is_terminator {
             // If it is EndIf, consume and record the position
             if let Some(token) = iter.peek()
-                && let EndIf = token.content()
+                && matches!(token.content(), EndIf)
             {
                 let pos = ().into_wrapper(token);
                 fallback_pos = Some(pos);

--- a/src/bms/ast/ast_build.rs
+++ b/src/bms/ast/ast_build.rs
@@ -291,21 +291,21 @@ fn parse_random_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
                     errors.append(&mut errs);
                     current_if_end = current_if_end.or(Some(end_if));
                 } else if let Some(ref max) = max_value {
-                    // Check if If branch value is out-of-range
-                    if !(&BigUint::from(1u64)..=max).contains(&if_val) {
+                    // Check if If branch value is in the range
+                    if (&BigUint::from(1u64)..=max).contains(&if_val) {
+                        seen_if_values.insert(if_val);
+                        let (tokens, mut errs, end_if) =
+                            parse_if_block_body(iter, ().into_wrapper(token));
+                        errors.append(&mut errs);
+                        branches.insert(if_val.clone(), tokens.into_wrapper(token));
+                        current_if_end = current_if_end.or(Some(end_if));
+                    } else {
                         errors.push(
                             AstBuildWarning::RandomIfBranchValueOutOfRange.into_wrapper(token),
                         );
                         let (_, mut errs, end_if) =
                             parse_if_block_body(iter, ().into_wrapper(token));
                         errors.append(&mut errs);
-                        current_if_end = current_if_end.or(Some(end_if));
-                    } else {
-                        seen_if_values.insert(if_val);
-                        let (tokens, mut errs, end_if) =
-                            parse_if_block_body(iter, ().into_wrapper(token));
-                        errors.append(&mut errs);
-                        branches.insert(if_val.clone(), tokens.into_wrapper(token));
                         current_if_end = current_if_end.or(Some(end_if));
                     }
                 } else {

--- a/src/bms/ast/ast_build.rs
+++ b/src/bms/ast/ast_build.rs
@@ -322,11 +322,10 @@ fn parse_random_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
                     .peek()
                     .map(|t| (t, t.content()))
                     .into_iter()
-                    .filter_map(|(t, c)| match c {
+                    .find_map(|(t, c)| match c {
                         ElseIf(val) => Some((t, val)),
                         _ => None,
                     })
-                    .next()
                 {
                     if seen_if_values.contains(elif_val) {
                         errors.push(

--- a/src/bms/ast/ast_build.rs
+++ b/src/bms/ast/ast_build.rs
@@ -667,9 +667,10 @@ mod tests {
                 }
             }
         }
-        if !found_nested {
-            panic!("Nested RandomBlock not found, if_blocks: {if_blocks:?}");
-        }
+        assert!(
+            found_nested,
+            "Nested RandomBlock not found, if_blocks: {if_blocks:?}"
+        );
     }
 
     #[test]

--- a/src/bms/ast/ast_build.rs
+++ b/src/bms/ast/ast_build.rs
@@ -32,16 +32,15 @@ pub(super) fn build_control_flow_ast<'a, T: Iterator<Item = &'a TokenWithRange<'
         let Some(token) = tokens_iter.peek() else {
             break;
         };
-        use Token::*;
         let rule = match token.content() {
-            EndIf => Some(AstBuildWarning::UnmatchedEndIf),
-            EndRandom => Some(AstBuildWarning::UnmatchedEndRandom),
-            EndSwitch => Some(AstBuildWarning::UnmatchedEndSwitch),
-            ElseIf(_) => Some(AstBuildWarning::UnmatchedElseIf),
-            Else => Some(AstBuildWarning::UnmatchedElse),
-            Skip => Some(AstBuildWarning::UnmatchedSkip),
-            Case(_) => Some(AstBuildWarning::UnmatchedCase),
-            Def => Some(AstBuildWarning::UnmatchedDef),
+            Token::EndIf => Some(AstBuildWarning::UnmatchedEndIf),
+            Token::EndRandom => Some(AstBuildWarning::UnmatchedEndRandom),
+            Token::EndSwitch => Some(AstBuildWarning::UnmatchedEndSwitch),
+            Token::ElseIf(_) => Some(AstBuildWarning::UnmatchedElseIf),
+            Token::Else => Some(AstBuildWarning::UnmatchedElse),
+            Token::Skip => Some(AstBuildWarning::UnmatchedSkip),
+            Token::Case(_) => Some(AstBuildWarning::UnmatchedCase),
+            Token::Def => Some(AstBuildWarning::UnmatchedDef),
             _ => None,
         };
         if let Some(rule) = rule {
@@ -58,13 +57,12 @@ fn parse_unit_or_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     iter: &mut Peekable<T>,
 ) -> Option<(Unit<'a>, Vec<AstBuildWarningWithRange>)> {
     let token = iter.peek()?;
-    use Token::*;
     match token.content() {
-        SetSwitch(_) | Switch(_) => {
+        Token::SetSwitch(_) | Token::Switch(_) => {
             let (unit, errs) = parse_switch_block(iter);
             Some((unit, errs))
         }
-        Random(_) | SetRandom(_) => {
+        Token::Random(_) | Token::SetRandom(_) => {
             let (unit, errs) = parse_random_block(iter);
             Some((unit, errs))
         }
@@ -82,8 +80,8 @@ fn parse_unit_or_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
 fn parse_switch_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     iter: &mut Peekable<T>,
 ) -> (Unit<'a>, Vec<AstBuildWarningWithRange>) {
-    let token = iter.next().unwrap();
     use Token::*;
+    let token = iter.next().unwrap();
     let block_value = match token.content() {
         SetSwitch(val) => BlockValue::Set { value: val.clone() },
         Switch(val) => BlockValue::Random { max: val.clone() },
@@ -221,9 +219,9 @@ fn parse_switch_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
 fn parse_case_or_def_body<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     iter: &mut Peekable<T>,
 ) -> (Vec<Unit<'a>>, Vec<AstBuildWarningWithRange>) {
+    use Token::*;
     let mut result = Vec::new();
     let mut errors = Vec::new();
-    use Token::*;
     while let Some(&token) = iter.peek() {
         if matches!(token.content(), Skip | EndSwitch | Case(_) | Def) {
             break;
@@ -261,9 +259,9 @@ fn parse_case_or_def_body<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
 fn parse_random_block<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     iter: &mut Peekable<T>,
 ) -> (Unit<'a>, Vec<AstBuildWarningWithRange>) {
+    use Token::*;
     // 1. Read the Random/SetRandom header to determine the max branch value
     let token = iter.next().unwrap();
-    use Token::*;
     let block_value = match token.content() {
         Random(val) => BlockValue::Random { max: val.clone() },
         SetRandom(val) => BlockValue::Set { value: val.clone() },
@@ -450,12 +448,12 @@ fn parse_if_block_body<'a, T: Iterator<Item = &'a TokenWithRange<'a>>>(
     Vec<AstBuildWarningWithRange>,
     SourceRangeMixin<()>,
 ) {
+    use Token::*;
     let mut result = Vec::new();
     let mut errors = Vec::new();
     // Default fallback: if no #ENDIF is found, use the position of the last processed token,
     // or the current peek token; if neither exists, use a dummy (0,0).
     let mut fallback_pos = None::<SourceRangeMixin<()>>;
-    use Token::*;
     loop {
         // First, check for terminators without holding the borrow across mutations
         let is_terminator = {

--- a/src/bms/ast/ast_extract.rs
+++ b/src/bms/ast/ast_extract.rs
@@ -100,10 +100,8 @@ fn extract_switch_block<'a>(
                 tokens.extend(extract_units(units));
 
                 // Add the Skip token
-                let (_skip_start, skip_end) = tokens
-                    .last()
-                    .map(|t| t.as_span())
-                    .unwrap_or(value.as_span());
+                let (_skip_start, skip_end) =
+                    tokens.last().map_or(value.as_span(), |t| t.as_span());
                 let skip_token = Token::Skip.into_wrapper_range(skip_end..skip_end);
                 tokens.push(skip_token);
             }
@@ -115,10 +113,8 @@ fn extract_switch_block<'a>(
                 tokens.extend(extract_units(units));
 
                 // Add the Skip token
-                let (_skip_start, skip_end) = tokens
-                    .last()
-                    .map(|t| t.as_span())
-                    .unwrap_or(value.as_span());
+                let (_skip_start, skip_end) =
+                    tokens.last().map_or(value.as_span(), |t| t.as_span());
                 let skip_token = Token::Skip.into_wrapper_range(skip_end..skip_end);
                 tokens.push(skip_token);
             }

--- a/src/bms/ast/ast_extract.rs
+++ b/src/bms/ast/ast_extract.rs
@@ -19,14 +19,14 @@ pub(super) fn extract_units<'a>(
                 if_blocks,
                 end_random,
             } => {
-                tokens.extend(extract_random_block(value, if_blocks, end_random));
+                tokens.extend(extract_random_block(&value, if_blocks, &end_random));
             }
             Unit::SwitchBlock {
                 value,
                 cases,
                 end_sw,
             } => {
-                tokens.extend(extract_switch_block(value, cases, end_sw));
+                tokens.extend(extract_switch_block(&value, cases, &end_sw));
             }
         }
     }
@@ -36,9 +36,9 @@ pub(super) fn extract_units<'a>(
 /// Extracts all tokens from a Random block.
 /// This function outputs ALL branches in the Random block, not just the selected one.
 fn extract_random_block<'a>(
-    value: SourceRangeMixin<BlockValue>,
+    value: &SourceRangeMixin<BlockValue>,
     if_blocks: impl IntoIterator<Item = IfBlock<'a>>,
-    end_random: SourceRangeMixin<()>,
+    end_random: &SourceRangeMixin<()>,
 ) -> Vec<TokenWithRange<'a>> {
     let mut tokens: Vec<TokenWithRange<'a>> = Vec::new();
 
@@ -48,7 +48,7 @@ fn extract_random_block<'a>(
     };
 
     // Add the Random token at the original header position
-    tokens.push(Token::Random(random_value).into_wrapper(&value));
+    tokens.push(Token::Random(random_value).into_wrapper(value));
 
     // Extract all If blocks and their branches
     for IfBlock { branches, end_if } in if_blocks {
@@ -67,7 +67,7 @@ fn extract_random_block<'a>(
     }
 
     // Add the EndRandom token at recorded position
-    tokens.push(Token::EndRandom.into_wrapper(&end_random));
+    tokens.push(Token::EndRandom.into_wrapper(end_random));
 
     tokens
 }
@@ -75,9 +75,9 @@ fn extract_random_block<'a>(
 /// Extracts all tokens from a Switch block.
 /// This function outputs ALL branches in the Switch block, not just the selected one.
 fn extract_switch_block<'a>(
-    value: SourceRangeMixin<BlockValue>,
+    value: &SourceRangeMixin<BlockValue>,
     cases: impl IntoIterator<Item = CaseBranch<'a>>,
-    end_sw: SourceRangeMixin<()>,
+    end_sw: &SourceRangeMixin<()>,
 ) -> Vec<TokenWithRange<'a>> {
     let mut tokens = Vec::new();
 
@@ -87,7 +87,7 @@ fn extract_switch_block<'a>(
         BlockValue::Set { value } => value,
     };
 
-    tokens.push(Token::Switch(switch_value).into_wrapper(&value));
+    tokens.push(Token::Switch(switch_value).into_wrapper(value));
 
     // Extract all case branches
     for CaseBranch { value, units } in cases {
@@ -126,7 +126,7 @@ fn extract_switch_block<'a>(
     }
 
     // Add the EndSwitch token at recorded ENDSW position
-    tokens.push(Token::EndSwitch.into_wrapper(&end_sw));
+    tokens.push(Token::EndSwitch.into_wrapper(end_sw));
 
     tokens
 }

--- a/src/bms/ast/ast_parse.rs
+++ b/src/bms/ast/ast_parse.rs
@@ -47,8 +47,7 @@ pub(super) fn parse_control_flow_ast<'a>(
                 let mut found = false;
                 if let Some(branch) = if_blocks
                     .iter()
-                    .flat_map(|if_block| if_block.branches.get(&branch_val))
-                    .next()
+                    .find_map(|if_block| if_block.branches.get(&branch_val))
                 {
                     let mut branch_iter = branch.content().clone().into_iter().peekable();
                     let (tokens, inner_warnings) = parse_control_flow_ast(&mut branch_iter, rng);
@@ -60,8 +59,7 @@ pub(super) fn parse_control_flow_ast<'a>(
                 if !found
                     && let Some(else_branch) = if_blocks
                         .iter()
-                        .flat_map(|if_block| if_block.branches.get(&BigUint::from(0u64)))
-                        .next()
+                        .find_map(|if_block| if_block.branches.get(&BigUint::from(0u64)))
                 {
                     let mut branch_iter = else_branch.content().clone().into_iter().peekable();
                     let (tokens, inner_warnings) = parse_control_flow_ast(&mut branch_iter, rng);

--- a/src/bms/ast/ast_parse.rs
+++ b/src/bms/ast/ast_parse.rs
@@ -109,7 +109,7 @@ pub(super) fn parse_control_flow_ast<'a>(
                 // If no Case matches, find the Def branch
                 if !found {
                     for case in &cases {
-                        if let CaseBranchValue::Def = case.value.content() {
+                        if matches!(case.value.content(), CaseBranchValue::Def) {
                             let mut case_iter = case.units.clone().into_iter().peekable();
                             let (tokens, inner_warnings) =
                                 parse_control_flow_ast(&mut case_iter, rng);

--- a/src/bms/ast/rng.rs
+++ b/src/bms/ast/rng.rs
@@ -13,11 +13,11 @@
 //!
 //! # Implementations
 //!
-//! ## RngMock
+//! ## [`RngMock`]
 //!
 //! A deterministic mock implementation for testing that returns predefined values in rotation:
 //!
-//! ## RandRng
+//! ## [`RandRng`]
 //!
 //! A production-ready implementation using the [`rand`] crate for true random number generation:
 //!

--- a/src/bms/ast/structure.rs
+++ b/src/bms/ast/structure.rs
@@ -38,13 +38,13 @@ pub enum Unit<'a> {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BlockValue {
     /// For Random/Switch, value ranges in [1, max].
-    /// IfBranch value must ranges in [1, max].
+    /// [`IfBranch`] value must ranges in [1, max].
     Random {
         /// The maximum value of the Random/Switch block.
         max: BigUint,
     },
     /// For SetRandom/SetSwitch.
-    /// IfBranch value has no limit.
+    /// [`IfBranch`] value has no limit.
     Set {
         /// The set value of the Random/Switch block.
         value: BigUint,
@@ -56,7 +56,7 @@ pub enum BlockValue {
 pub struct IfBlock<'a> {
     /// The branches of the If block.
     pub branches: BTreeMap<BigUint, SourceRangeMixin<Vec<Unit<'a>>>>,
-    /// The ENDIF position in the BMS source for this IfBlock.
+    /// The ENDIF position in the BMS source for this [`IfBlock`].
     /// If there is no matching `#ENDIF`, this falls back to the position of the last token
     /// inside the If block (or the current peek position when the block is empty).
     pub end_if: SourceRangeMixin<()>,

--- a/src/bms/command.rs
+++ b/src/bms/command.rs
@@ -63,21 +63,18 @@ impl From<i64> for JudgeLevel {
 impl<'a> TryFrom<&'a str> for JudgeLevel {
     type Error = &'a str;
     fn try_from(value: &'a str) -> core::result::Result<Self, Self::Error> {
-        value
-            .parse::<i64>()
-            .map(JudgeLevel::from)
-            .map_err(|_| value)
+        value.parse::<i64>().map(Self::from).map_err(|_| value)
     }
 }
 
 impl std::fmt::Display for JudgeLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            JudgeLevel::VeryHard => write!(f, "0"),
-            JudgeLevel::Hard => write!(f, "1"),
-            JudgeLevel::Normal => write!(f, "2"),
-            JudgeLevel::Easy => write!(f, "3"),
-            JudgeLevel::OtherInt(value) => write!(f, "{}", value),
+            Self::VeryHard => write!(f, "0"),
+            Self::Hard => write!(f, "1"),
+            Self::Normal => write!(f, "2"),
+            Self::Easy => write!(f, "3"),
+            Self::OtherInt(value) => write!(f, "{}", value),
         }
     }
 }
@@ -281,9 +278,9 @@ impl TryFrom<u8> for LnMode {
     type Error = u8;
     fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
         Ok(match value {
-            1 => LnMode::Ln,
-            2 => LnMode::Cn,
-            3 => LnMode::Hcn,
+            1 => Self::Ln,
+            2 => Self::Cn,
+            3 => Self::Hcn,
             _ => return Err(value),
         })
     }

--- a/src/bms/command.rs
+++ b/src/bms/command.rs
@@ -184,21 +184,25 @@ impl From<ObjId> for u64 {
 
 impl ObjId {
     /// Instances a special null id, which means the rest object.
+    #[must_use]
     pub const fn null() -> Self {
         Self([0, 0])
     }
 
     /// Converts the object id into an `u16` value.
+    #[must_use]
     pub fn as_u16(self) -> u16 {
         self.into()
     }
 
     /// Converts the object id into an `u32` value.
+    #[must_use]
     pub fn as_u32(self) -> u32 {
         self.into()
     }
 
     /// Converts the object id into an `u64` value.
+    #[must_use]
     pub fn as_u64(self) -> u64 {
         self.into()
     }

--- a/src/bms/command.rs
+++ b/src/bms/command.rs
@@ -74,7 +74,7 @@ impl std::fmt::Display for JudgeLevel {
             Self::Hard => write!(f, "1"),
             Self::Normal => write!(f, "2"),
             Self::Easy => write!(f, "3"),
-            Self::OtherInt(value) => write!(f, "{}", value),
+            Self::OtherInt(value) => write!(f, "{value}"),
         }
     }
 }

--- a/src/bms/command.rs
+++ b/src/bms/command.rs
@@ -82,7 +82,7 @@ impl std::fmt::Display for JudgeLevel {
     }
 }
 
-pub(crate) fn char_to_base62(ch: char) -> Option<u8> {
+pub(crate) const fn char_to_base62(ch: char) -> Option<u8> {
     match ch {
         '0'..='9' | 'A'..='Z' | 'a'..='z' => Some(ch as u32 as u8),
         _ => None,
@@ -207,7 +207,7 @@ impl ObjId {
     }
 
     /// Makes the object id uppercase.
-    pub fn make_uppercase(&mut self) {
+    pub const fn make_uppercase(&mut self) {
         self.0[0] = self.0[0].to_ascii_uppercase();
         self.0[1] = self.0[1].to_ascii_uppercase();
     }

--- a/src/bms/command.rs
+++ b/src/bms/command.rs
@@ -27,11 +27,10 @@ pub enum PlayerMode {
 
 /// A rank to determine judge level, but treatment differs among the BMS players.
 ///
-/// IIDX/LR2/beatoraja judge windows: https://iidx.org/misc/iidx_lr2_beatoraja_diff
+/// IIDX/LR2/beatoraja judge windows: <https://iidx.org/misc/iidx_lr2_beatoraja_diff>
 ///
-/// Note: VeryEasy is not Implemented.
-/// For `#RANK 4`, `#RANK 6` and `#RANK -1`: Usage differs among the BMS players.
-/// See: https://github.com/MikuroXina/bms-rs/pull/122
+/// Note: The difficulty `VeryEasy` is decided to be unimplemented.
+/// See [discussions in the PR](https://github.com/MikuroXina/bms-rs/pull/122).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum JudgeLevel {
@@ -44,7 +43,7 @@ pub enum JudgeLevel {
     /// Rank 3, the easier rank.
     Easy,
     /// Other integer value. Please See `JudgeLevel` for more details.
-    /// If used for ExRank, representing precentage.
+    /// If used for `#EXRANK`, representing percentage.
     OtherInt(i64),
 }
 

--- a/src/bms/command/channel.rs
+++ b/src/bms/command/channel.rs
@@ -154,11 +154,13 @@ pub enum NoteKind {
 
 impl NoteKind {
     /// Returns whether the note is a playable.
+    #[must_use]
     pub const fn is_playable(self) -> bool {
         !matches!(self, Self::Invisible)
     }
 
     /// Returns whether the note is a long-press note.
+    #[must_use]
     pub const fn is_long(self) -> bool {
         matches!(self, Self::Long)
     }
@@ -257,6 +259,7 @@ impl From<ChannelId> for u64 {
 
 impl ChannelId {
     /// Converts the channel id into an `u16` value.
+    #[must_use]
     pub fn as_u16(self) -> u16 {
         self.into()
     }
@@ -296,11 +299,13 @@ pub enum Key {
 
 impl Key {
     /// Returns whether the key expected a piano keyboard.
+    #[must_use]
     pub const fn is_keyxx(&self) -> bool {
         matches!(self, Self::Key(_))
     }
 
     /// Returns the key number if it's a Key variant.
+    #[must_use]
     pub const fn key_number(&self) -> Option<u8> {
         match self {
             Self::Key(n) => Some(*n),
@@ -309,6 +314,7 @@ impl Key {
     }
 
     /// Returns the scratch number if it's a Scratch variant.
+    #[must_use]
     pub const fn scratch_number(&self) -> Option<u8> {
         match self {
             Self::Scratch(n) => Some(*n),
@@ -317,11 +323,13 @@ impl Key {
     }
 
     /// Creates a Key variant with the given number.
+    #[must_use]
     pub const fn new_key(n: u8) -> Self {
         Self::Key(n)
     }
 
     /// Creates a Scratch variant with the given number.
+    #[must_use]
     pub const fn new_scratch(n: u8) -> Self {
         Self::Scratch(n)
     }
@@ -375,6 +383,7 @@ fn read_channel_general(channel: &str) -> Option<Channel> {
 }
 
 /// Reads a channel from a string. (Generic channel reader)
+#[must_use]
 pub fn read_channel(channel: &str) -> Option<Channel> {
     if let Some(channel) = read_channel_general(channel) {
         return Some(channel);

--- a/src/bms/command/channel.rs
+++ b/src/bms/command/channel.rs
@@ -94,46 +94,46 @@ impl std::fmt::Display for Channel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Channel: ")?;
         match self {
-            Channel::BgaBase => write!(f, "BGA"),
-            Channel::BgaLayer => write!(f, "BGA_LAYER"),
-            Channel::BgaPoor => write!(f, "BGA_POOR"),
-            Channel::Bgm => write!(f, "BGM"),
-            Channel::BpmChangeU8 => write!(f, "BPM_CHANGE_U8"),
-            Channel::BpmChange => write!(f, "BPM_CHANGE"),
+            Self::BgaBase => write!(f, "BGA"),
+            Self::BgaLayer => write!(f, "BGA_LAYER"),
+            Self::BgaPoor => write!(f, "BGA_POOR"),
+            Self::Bgm => write!(f, "BGM"),
+            Self::BpmChangeU8 => write!(f, "BPM_CHANGE_U8"),
+            Self::BpmChange => write!(f, "BPM_CHANGE"),
             #[cfg(feature = "minor-command")]
-            Channel::ChangeOption => write!(f, "CHANGE_OPTION"),
-            Channel::Note { .. } => write!(f, "NOTE"),
-            Channel::SectionLen => write!(f, "SECTION_LEN"),
-            Channel::Stop => write!(f, "STOP"),
-            Channel::Scroll => write!(f, "SCROLL"),
-            Channel::Speed => write!(f, "SPEED"),
+            Self::ChangeOption => write!(f, "CHANGE_OPTION"),
+            Self::Note { .. } => write!(f, "NOTE"),
+            Self::SectionLen => write!(f, "SECTION_LEN"),
+            Self::Stop => write!(f, "STOP"),
+            Self::Scroll => write!(f, "SCROLL"),
+            Self::Speed => write!(f, "SPEED"),
             #[cfg(feature = "minor-command")]
-            Channel::Seek => write!(f, "SEEK"),
-            Channel::BgaLayer2 => write!(f, "BGA_LAYER2"),
+            Self::Seek => write!(f, "SEEK"),
+            Self::BgaLayer2 => write!(f, "BGA_LAYER2"),
             #[cfg(feature = "minor-command")]
-            Channel::BgaBaseOpacity => write!(f, "BGA_BASE_OPACITY"),
+            Self::BgaBaseOpacity => write!(f, "BGA_BASE_OPACITY"),
             #[cfg(feature = "minor-command")]
-            Channel::BgaLayerOpacity => write!(f, "BGA_LAYER_OPACITY"),
+            Self::BgaLayerOpacity => write!(f, "BGA_LAYER_OPACITY"),
             #[cfg(feature = "minor-command")]
-            Channel::BgaLayer2Opacity => write!(f, "BGA_LAYER2_OPACITY"),
+            Self::BgaLayer2Opacity => write!(f, "BGA_LAYER2_OPACITY"),
             #[cfg(feature = "minor-command")]
-            Channel::BgaPoorOpacity => write!(f, "BGA_POOR_OPACITY"),
-            Channel::BgmVolume => write!(f, "BGM_VOLUME"),
-            Channel::KeyVolume => write!(f, "KEY_VOLUME"),
-            Channel::Text => write!(f, "TEXT"),
-            Channel::Judge => write!(f, "JUDGE"),
+            Self::BgaPoorOpacity => write!(f, "BGA_POOR_OPACITY"),
+            Self::BgmVolume => write!(f, "BGM_VOLUME"),
+            Self::KeyVolume => write!(f, "KEY_VOLUME"),
+            Self::Text => write!(f, "TEXT"),
+            Self::Judge => write!(f, "JUDGE"),
             #[cfg(feature = "minor-command")]
-            Channel::BgaBaseArgb => write!(f, "BGA_BASE_ARGB"),
+            Self::BgaBaseArgb => write!(f, "BGA_BASE_ARGB"),
             #[cfg(feature = "minor-command")]
-            Channel::BgaLayerArgb => write!(f, "BGA_LAYER_ARGB"),
+            Self::BgaLayerArgb => write!(f, "BGA_LAYER_ARGB"),
             #[cfg(feature = "minor-command")]
-            Channel::BgaLayer2Argb => write!(f, "BGA_LAYER2_ARGB"),
+            Self::BgaLayer2Argb => write!(f, "BGA_LAYER2_ARGB"),
             #[cfg(feature = "minor-command")]
-            Channel::BgaPoorArgb => write!(f, "BGA_POOR_ARGB"),
+            Self::BgaPoorArgb => write!(f, "BGA_POOR_ARGB"),
             #[cfg(feature = "minor-command")]
-            Channel::BgaKeybound => write!(f, "BGA_KEYBOUND"),
+            Self::BgaKeybound => write!(f, "BGA_KEYBOUND"),
             #[cfg(feature = "minor-command")]
-            Channel::Option => write!(f, "OPTION"),
+            Self::Option => write!(f, "OPTION"),
         }
     }
 }

--- a/src/bms/command/channel.rs
+++ b/src/bms/command/channel.rs
@@ -45,10 +45,10 @@ pub enum Channel {
     Scroll,
     /// For the note spacing change object.
     Speed,
-    /// For the video seek object. #SEEKxx n
+    /// For the video seek object. `#SEEKxx n`
     #[cfg(feature = "minor-command")]
     Seek,
-    /// For the BGA LAYER2 object. #BMPxx (LAYER2 is layered over LAYER)
+    /// For the BGA LAYER2 object. `#BMPxx` (LAYER2 is layered over LAYER)
     BgaLayer2,
     /// For the opacity of BGA BASE. transparent « [01-FF] » opaque
     #[cfg(feature = "minor-command")]
@@ -66,26 +66,26 @@ pub enum Channel {
     BgmVolume,
     /// For the KEY volume. min 1 « [01-FF] » max 255 (= original sound)
     KeyVolume,
-    /// For the TEXT object. #TEXTxx "string"
+    /// For the TEXT object. `#TEXTxx "string"`
     Text,
-    /// For the JUDGE object. #EXRANKxx n (100 corresponds to RANK:NORMAL. integer or decimal fraction)
+    /// For the JUDGE object. `#EXRANKxx n` (100 corresponds to RANK:NORMAL. integer or decimal fraction)
     Judge,
-    /// For the BGA BASE aRGB. #ARGBxx a,r,g,b (each [0-255])
+    /// For the BGA BASE aRGB. `#ARGBxx a,r,g,b` (each [0-255])
     #[cfg(feature = "minor-command")]
     BgaBaseArgb,
-    /// For the BGA LAYER aRGB. #ARGBxx
+    /// For the BGA LAYER aRGB. `#ARGBxx`
     #[cfg(feature = "minor-command")]
     BgaLayerArgb,
-    /// For the BGA LAYER2 aRGB. #ARGBxx
+    /// For the BGA LAYER2 aRGB. `#ARGBxx`
     #[cfg(feature = "minor-command")]
     BgaLayer2Argb,
-    /// For the BGA POOR aRGB. #ARGBxx
+    /// For the BGA POOR aRGB. `#ARGBxx`
     #[cfg(feature = "minor-command")]
     BgaPoorArgb,
-    /// For the BGA KEYBOUND. #SWBGAxx
+    /// For the BGA KEYBOUND. `#SWBGAxx`
     #[cfg(feature = "minor-command")]
     BgaKeybound,
-    /// For the OPTION. #CHANGEOPTIONxx (multiline)
+    /// For the OPTION. `#CHANGEOPTIONxx` (multiline)
     #[cfg(feature = "minor-command")]
     Option,
 }
@@ -177,7 +177,7 @@ pub enum PlayerSide {
     Player2,
 }
 
-/// Error type for parsing ChannelId from string.
+/// Error type for parsing [`ChannelId`] from string.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Error)]
 pub enum ChannelIdParseError {
     /// The channel id must be exactly 2 ascii characters, got `{0}`.

--- a/src/bms/command/channel/converter.rs
+++ b/src/bms/command/channel/converter.rs
@@ -65,20 +65,20 @@ impl JavaRandom {
         }
     }
 
-    /// Java's next(int bits) method
+    /// Java's `next(int bits)` method
     const fn next(&mut self, bits: i32) -> i32 {
         self.seed =
             (self.seed.wrapping_mul(Self::MULT).wrapping_add(Self::ADD)) & ((1u64 << 48) - 1);
         ((self.seed >> (48 - bits)) & ((1u64 << bits) - 1)) as i32
     }
 
-    /// Java's nextInt() method - returns any int value
+    /// Java's `nextInt()` method - returns any int value
     #[allow(dead_code)]
     pub const fn next_int(&mut self) -> i32 {
         self.next(32)
     }
 
-    /// Java's nextInt(int bound) method
+    /// Java's `nextInt(int bound)` method
     pub fn next_int_bound(&mut self, bound: i32) -> i32 {
         if bound <= 0 {
             panic!("bound must be positive");
@@ -274,7 +274,7 @@ mod channel_mode_tests {
 
     /// Test the random shuffle modifier.
     ///
-    /// Source: https://www.bilibili.com/opus/1033281595747860483
+    /// Source: <https://www.bilibili.com/opus/1033281595747860483>
     #[test]
     fn test_random_shuffle() {
         let examples = [

--- a/src/bms/command/channel/converter.rs
+++ b/src/bms/command/channel/converter.rs
@@ -108,10 +108,10 @@ pub struct KeyLayoutConvertLaneRotateShuffle {
 
 impl KeyLayoutConvertLaneRotateShuffle {
     /// Create a new [`KeyLayoutConvertLaneRotateShuffle`] with the given [`PlayerSide`], [`Key`]s and seed.
-    pub fn new(side: PlayerSide, keys: Vec<Key>, seed: i64) -> Self {
+    pub fn new(side: PlayerSide, keys: &[Key], seed: i64) -> Self {
         Self {
             side,
-            arrangement: Self::make_random(&keys, seed),
+            arrangement: Self::make_random(keys, seed),
         }
     }
 
@@ -163,10 +163,10 @@ pub struct KeyLayoutConvertLaneRandomShuffle {
 
 impl KeyLayoutConvertLaneRandomShuffle {
     /// Create a new [`KeyLayoutConvertLaneRandomShuffle`] with the given [`PlayerSide`], [`Key`]s and seed.
-    pub fn new(side: PlayerSide, keys: Vec<Key>, seed: i64) -> Self {
+    pub fn new(side: PlayerSide, keys: &[Key], seed: i64) -> Self {
         Self {
             side,
-            arrangement: Self::make_random(&keys, seed),
+            arrangement: Self::make_random(keys, seed),
         }
     }
 
@@ -306,11 +306,8 @@ mod channel_mode_tests {
                 Key::Key(6),
                 Key::Key(7),
             ];
-            let mut rnd = KeyLayoutConvertLaneRandomShuffle::new(
-                PlayerSide::Player1,
-                init_keys.to_vec(),
-                *seed,
-            );
+            let mut rnd =
+                KeyLayoutConvertLaneRandomShuffle::new(PlayerSide::Player1, &init_keys, *seed);
             let result_values = init_keys
                 .into_iter()
                 .map(|k| {

--- a/src/bms/command/channel/converter.rs
+++ b/src/bms/command/channel/converter.rs
@@ -54,9 +54,12 @@ struct JavaRandom {
 }
 
 impl JavaRandom {
+    const MULT: u64 = 0x5_DEEC_E66D;
+    const ADD: u64 = 0xB;
+
     /// Create a new [`JavaRandom`] with the given seed.
     pub const fn new(seed: i64) -> Self {
-        let s = (seed as u64) ^ 0x5DEECE66D;
+        let s = (seed as u64) ^ Self::MULT;
         Self {
             seed: s & ((1u64 << 48) - 1),
         }
@@ -64,9 +67,8 @@ impl JavaRandom {
 
     /// Java's next(int bits) method
     const fn next(&mut self, bits: i32) -> i32 {
-        const MULT: u64 = 0x5DEECE66D;
-        const ADD: u64 = 0xB;
-        self.seed = (self.seed.wrapping_mul(MULT).wrapping_add(ADD)) & ((1u64 << 48) - 1);
+        self.seed =
+            (self.seed.wrapping_mul(Self::MULT).wrapping_add(Self::ADD)) & ((1u64 << 48) - 1);
         ((self.seed >> (48 - bits)) & ((1u64 << bits) - 1)) as i32
     }
 

--- a/src/bms/command/channel/converter.rs
+++ b/src/bms/command/channel/converter.rs
@@ -16,6 +16,7 @@ pub trait KeyLayoutConverter {
 
 impl KeyLayoutConvertMirror {
     /// Create a new [`KeyLayoutConvertMirror`] with the given [`PlayerSide`] and [`Key`]s.
+    #[must_use]
     pub const fn new(side: PlayerSide, keys: Vec<Key>) -> Self {
         Self { side, keys }
     }
@@ -108,6 +109,7 @@ pub struct KeyLayoutConvertLaneRotateShuffle {
 
 impl KeyLayoutConvertLaneRotateShuffle {
     /// Create a new [`KeyLayoutConvertLaneRotateShuffle`] with the given [`PlayerSide`], [`Key`]s and seed.
+    #[must_use]
     pub fn new(side: PlayerSide, keys: &[Key], seed: i64) -> Self {
         Self {
             side,
@@ -163,6 +165,7 @@ pub struct KeyLayoutConvertLaneRandomShuffle {
 
 impl KeyLayoutConvertLaneRandomShuffle {
     /// Create a new [`KeyLayoutConvertLaneRandomShuffle`] with the given [`PlayerSide`], [`Key`]s and seed.
+    #[must_use]
     pub fn new(side: PlayerSide, keys: &[Key], seed: i64) -> Self {
         Self {
             side,

--- a/src/bms/command/channel/converter.rs
+++ b/src/bms/command/channel/converter.rs
@@ -56,7 +56,7 @@ impl JavaRandom {
     /// Create a new [`JavaRandom`] with the given seed.
     pub const fn new(seed: i64) -> Self {
         let s = (seed as u64) ^ 0x5DEECE66D;
-        JavaRandom {
+        Self {
             seed: s & ((1u64 << 48) - 1),
         }
     }
@@ -109,7 +109,7 @@ pub struct KeyLayoutConvertLaneRotateShuffle {
 impl KeyLayoutConvertLaneRotateShuffle {
     /// Create a new [`KeyLayoutConvertLaneRotateShuffle`] with the given [`PlayerSide`], [`Key`]s and seed.
     pub fn new(side: PlayerSide, keys: Vec<Key>, seed: i64) -> Self {
-        KeyLayoutConvertLaneRotateShuffle {
+        Self {
             side,
             arrangement: Self::make_random(&keys, seed),
         }
@@ -164,7 +164,7 @@ pub struct KeyLayoutConvertLaneRandomShuffle {
 impl KeyLayoutConvertLaneRandomShuffle {
     /// Create a new [`KeyLayoutConvertLaneRandomShuffle`] with the given [`PlayerSide`], [`Key`]s and seed.
     pub fn new(side: PlayerSide, keys: Vec<Key>, seed: i64) -> Self {
-        KeyLayoutConvertLaneRandomShuffle {
+        Self {
             side,
             arrangement: Self::make_random(&keys, seed),
         }

--- a/src/bms/command/channel/converter.rs
+++ b/src/bms/command/channel/converter.rs
@@ -16,7 +16,7 @@ pub trait KeyLayoutConverter {
 
 impl KeyLayoutConvertMirror {
     /// Create a new [`KeyLayoutConvertMirror`] with the given [`PlayerSide`] and [`Key`]s.
-    pub fn new(side: PlayerSide, keys: Vec<Key>) -> Self {
+    pub const fn new(side: PlayerSide, keys: Vec<Key>) -> Self {
         Self { side, keys }
     }
 }
@@ -54,7 +54,7 @@ struct JavaRandom {
 
 impl JavaRandom {
     /// Create a new [`JavaRandom`] with the given seed.
-    pub fn new(seed: i64) -> Self {
+    pub const fn new(seed: i64) -> Self {
         let s = (seed as u64) ^ 0x5DEECE66D;
         JavaRandom {
             seed: s & ((1u64 << 48) - 1),
@@ -62,7 +62,7 @@ impl JavaRandom {
     }
 
     /// Java's next(int bits) method
-    fn next(&mut self, bits: i32) -> i32 {
+    const fn next(&mut self, bits: i32) -> i32 {
         const MULT: u64 = 0x5DEECE66D;
         const ADD: u64 = 0xB;
         self.seed = (self.seed.wrapping_mul(MULT).wrapping_add(ADD)) & ((1u64 << 48) - 1);
@@ -71,7 +71,7 @@ impl JavaRandom {
 
     /// Java's nextInt() method - returns any int value
     #[allow(dead_code)]
-    pub fn next_int(&mut self) -> i32 {
+    pub const fn next_int(&mut self) -> i32 {
         self.next(32)
     }
 

--- a/src/bms/command/channel/converter.rs
+++ b/src/bms/command/channel/converter.rs
@@ -80,9 +80,7 @@ impl JavaRandom {
 
     /// Java's `nextInt(int bound)` method
     pub fn next_int_bound(&mut self, bound: i32) -> i32 {
-        if bound <= 0 {
-            panic!("bound must be positive");
-        }
+        assert!(bound > 0, "bound must be positive");
 
         let m = bound - 1;
         if (bound & m) == 0 {

--- a/src/bms/command/channel/mapper.rs
+++ b/src/bms/command/channel/mapper.rs
@@ -246,8 +246,8 @@ impl KeyLayoutMapper for KeyLayoutPms {
     }
 
     fn from_channel_id(channel_id: ChannelId) -> Option<Self> {
-        let beat = channel_id_to_key_layout_beat(channel_id)?;
         use PlayerSide::*;
+        let beat = channel_id_to_key_layout_beat(channel_id)?;
         let (side, kind, key) = beat.into_tuple();
         let (side, key) = match (side, key) {
             (Player1, Key(1..=5)) => (Player1, key),
@@ -364,8 +364,8 @@ impl KeyLayoutMapper for KeyLayoutDscOctFp {
     }
 
     fn from_channel_id(channel_id: ChannelId) -> Option<Self> {
-        let beat = channel_id_to_key_layout_beat(channel_id)?;
         use PlayerSide::*;
+        let beat = channel_id_to_key_layout_beat(channel_id)?;
         let (side, kind, key) = beat.into_tuple();
         let (side, key) = match (side, key) {
             (Player1, Key(1..=7) | Scratch(1)) => (Player1, key),

--- a/src/bms/command/channel/mapper.rs
+++ b/src/bms/command/channel/mapper.rs
@@ -3,7 +3,7 @@
 use super::{ChannelId, Key, NoteKind, PlayerSide};
 use Key::*;
 
-/// Convert from KeyLayoutBeat to ChannelId.
+/// Convert from [`KeyLayoutBeat`] to [`ChannelId`].
 fn key_layout_beat_to_channel_id(beat: KeyLayoutBeat) -> ChannelId {
     let (side, kind, key) = beat.into_tuple();
 
@@ -36,7 +36,7 @@ fn key_layout_beat_to_channel_id(beat: KeyLayoutBeat) -> ChannelId {
     ChannelId::try_from([first_char as u8, second_char as u8]).unwrap()
 }
 
-/// Convert from ChannelId to KeyLayoutBeat.
+/// Convert from [`ChannelId`] to [`KeyLayoutBeat`].
 fn channel_id_to_key_layout_beat(channel_id: ChannelId) -> Option<KeyLayoutBeat> {
     let chars = channel_id.0.map(|c| c as char);
     let first_char = chars[0];
@@ -76,9 +76,9 @@ fn channel_id_to_key_layout_beat(channel_id: ChannelId) -> Option<KeyLayoutBeat>
 pub trait KeyMapping {
     /// Create a new [`KeyMapping`] from a [`PlayerSide`], [`NoteKind`] and [`Key`].
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self;
-    /// Get the PlayerSide from this KeyMapping.
+    /// Get the [`PlayerSide`] from this [`KeyMapping`].
     fn side(&self) -> PlayerSide;
-    /// Get the NoteKind from this KeyMapping.
+    /// Get the [`NoteKind`] from this [`KeyMapping`].
     fn kind(&self) -> NoteKind;
     /// Get the [`Key`] from this [`KeyMapping`].
     fn key(&self) -> Key;
@@ -88,19 +88,19 @@ pub trait KeyMapping {
 /// Trait for key channel mode implementations.
 ///
 /// This trait defines the interface for converting between different key channel modes
-/// and the standard ChannelId format. Each mode implementation should provide methods to
-/// convert from its own format to ChannelId format and vice versa.
+/// and the standard [`ChannelId`] format. Each mode implementation should provide methods to
+/// convert from its own format to [`ChannelId`] format and vice versa.
 pub trait KeyLayoutMapper: KeyMapping {
-    /// Convert from this mode's format to ChannelId format.
+    /// Convert from this mode's format to [`ChannelId`] format.
     ///
-    /// This method takes a (PlayerSide, NoteKind, Key) tuple in this mode's format and converts
-    /// it to the equivalent ChannelId in ChannelId format.
+    /// This method takes a ([`PlayerSide`], [`NoteKind`], [`Key`]) tuple in this mode's format and converts
+    /// it to the equivalent [`ChannelId`] in [`ChannelId`] format.
     fn to_channel_id(self) -> ChannelId;
 
-    /// Convert from ChannelId format to this mode's format.
+    /// Convert from [`ChannelId`] format to this mode's format.
     ///
-    /// This method takes a ChannelId in ChannelId format and converts
-    /// it to the equivalent (PlayerSide, NoteKind, Key) tuple in this mode's format.
+    /// This method takes a [`ChannelId`] in [`ChannelId`] format and converts
+    /// it to the equivalent ([`PlayerSide`], [`NoteKind`], [`Key`]) tuple in this mode's format.
     fn from_channel_id(channel_id: ChannelId) -> Option<Self>
     where
         Self: Sized;

--- a/src/bms/command/channel/mapper.rs
+++ b/src/bms/command/channel/mapper.rs
@@ -116,7 +116,7 @@ pub struct KeyLayoutBeat(pub PlayerSide, pub NoteKind, pub Key);
 
 impl KeyMapping for KeyLayoutBeat {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
-        KeyLayoutBeat(side, kind, key)
+        Self(side, kind, key)
     }
 
     fn side(&self) -> PlayerSide {
@@ -155,7 +155,7 @@ pub struct KeyLayoutPmsBmeType(pub PlayerSide, pub NoteKind, pub Key);
 
 impl KeyMapping for KeyLayoutPmsBmeType {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
-        KeyLayoutPmsBmeType(side, kind, key)
+        Self(side, kind, key)
     }
 
     fn side(&self) -> PlayerSide {
@@ -195,7 +195,7 @@ impl KeyLayoutMapper for KeyLayoutPmsBmeType {
             FreeZone => Key(9),
             _ => key,
         };
-        Some(KeyLayoutPmsBmeType::new(side, kind, key))
+        Some(Self::new(side, kind, key))
     }
 }
 
@@ -209,7 +209,7 @@ pub struct KeyLayoutPms(pub PlayerSide, pub NoteKind, pub Key);
 
 impl KeyMapping for KeyLayoutPms {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
-        KeyLayoutPms(side, kind, key)
+        Self(side, kind, key)
     }
 
     fn side(&self) -> PlayerSide {
@@ -257,7 +257,7 @@ impl KeyLayoutMapper for KeyLayoutPms {
             (Player2, Key(5)) => (Player1, Key(9)),
             other => other,
         };
-        Some(KeyLayoutPms::new(side, kind, key))
+        Some(Self::new(side, kind, key))
     }
 }
 
@@ -271,7 +271,7 @@ pub struct KeyLayoutBeatNanasi(pub PlayerSide, pub NoteKind, pub Key);
 
 impl KeyMapping for KeyLayoutBeatNanasi {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
-        KeyLayoutBeatNanasi(side, kind, key)
+        Self(side, kind, key)
     }
 
     fn side(&self) -> PlayerSide {
@@ -309,7 +309,7 @@ impl KeyLayoutMapper for KeyLayoutBeatNanasi {
             FreeZone => FootPedal,
             other => other,
         };
-        Some(KeyLayoutBeatNanasi::new(side, kind, key))
+        Some(Self::new(side, kind, key))
     }
 }
 
@@ -323,7 +323,7 @@ pub struct KeyLayoutDscOctFp(pub PlayerSide, pub NoteKind, pub Key);
 
 impl KeyMapping for KeyLayoutDscOctFp {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
-        KeyLayoutDscOctFp(side, kind, key)
+        Self(side, kind, key)
     }
 
     fn side(&self) -> PlayerSide {
@@ -385,6 +385,6 @@ impl KeyLayoutMapper for KeyLayoutDscOctFp {
             (Player2, Scratch(1)) => (Player1, Scratch(2)),
             (s, k) => (s, k),
         };
-        Some(KeyLayoutDscOctFp::new(side, kind, key))
+        Some(Self::new(side, kind, key))
     }
 }

--- a/src/bms/command/channel/mapper.rs
+++ b/src/bms/command/channel/mapper.rs
@@ -234,7 +234,7 @@ impl KeyLayoutMapper for KeyLayoutPms {
         use PlayerSide::*;
         let (side, kind, key) = self.into_tuple();
         let (side, key) = match (side, key) {
-            (Player1, Key(1) | Key(2) | Key(3) | Key(4) | Key(5)) => (Player1, key),
+            (Player1, Key(1..=5)) => (Player1, key),
             (Player1, Key(6)) => (Player2, Key(2)),
             (Player1, Key(7)) => (Player2, Key(3)),
             (Player1, Key(8)) => (Player2, Key(4)),
@@ -250,7 +250,7 @@ impl KeyLayoutMapper for KeyLayoutPms {
         use PlayerSide::*;
         let (side, kind, key) = beat.into_tuple();
         let (side, key) = match (side, key) {
-            (Player1, Key(1) | Key(2) | Key(3) | Key(4) | Key(5)) => (Player1, key),
+            (Player1, Key(1..=5)) => (Player1, key),
             (Player2, Key(2)) => (Player1, Key(6)),
             (Player2, Key(3)) => (Player1, Key(7)),
             (Player2, Key(4)) => (Player1, Key(8)),
@@ -348,10 +348,7 @@ impl KeyLayoutMapper for KeyLayoutDscOctFp {
         use PlayerSide::*;
         let (side, kind, key) = self.into_tuple();
         let (side, key) = match (side, key) {
-            (
-                Player1,
-                Key(1) | Key(2) | Key(3) | Key(4) | Key(5) | Key(6) | Key(7) | Scratch(1),
-            ) => (Player1, key),
+            (Player1, Key(1..=7) | Scratch(1)) => (Player1, key),
             (Player1, Scratch(2)) => (Player2, Scratch(1)),
             (Player1, FootPedal) => (Player2, Key(1)),
             (Player1, Key(8)) => (Player2, Key(2)),
@@ -371,10 +368,7 @@ impl KeyLayoutMapper for KeyLayoutDscOctFp {
         use PlayerSide::*;
         let (side, kind, key) = beat.into_tuple();
         let (side, key) = match (side, key) {
-            (
-                Player1,
-                Key(1) | Key(2) | Key(3) | Key(4) | Key(5) | Key(6) | Key(7) | Scratch(1),
-            ) => (Player1, key),
+            (Player1, Key(1..=7) | Scratch(1)) => (Player1, key),
             (Player2, Key(1)) => (Player1, FootPedal),
             (Player2, Key(2)) => (Player1, Key(8)),
             (Player2, Key(3)) => (Player1, Key(9)),

--- a/src/bms/command/graphics.rs
+++ b/src/bms/command/graphics.rs
@@ -12,6 +12,7 @@ pub struct PixelPoint {
 
 impl PixelPoint {
     /// Creates a new pixel point.
+    #[must_use]
     pub const fn new(x: i16, y: i16) -> Self {
         Self { x, y }
     }
@@ -41,6 +42,7 @@ pub struct PixelSize {
 
 impl PixelSize {
     /// Creates a new pixel size.
+    #[must_use]
     pub const fn new(width: u16, height: u16) -> Self {
         Self { width, height }
     }

--- a/src/bms/command/graphics.rs
+++ b/src/bms/command/graphics.rs
@@ -12,7 +12,7 @@ pub struct PixelPoint {
 
 impl PixelPoint {
     /// Creates a new pixel point.
-    pub fn new(x: i16, y: i16) -> Self {
+    pub const fn new(x: i16, y: i16) -> Self {
         Self { x, y }
     }
 }
@@ -41,7 +41,7 @@ pub struct PixelSize {
 
 impl PixelSize {
     /// Creates a new pixel size.
-    pub fn new(width: u16, height: u16) -> Self {
+    pub const fn new(width: u16, height: u16) -> Self {
         Self { width, height }
     }
 }

--- a/src/bms/command/minor_command.rs
+++ b/src/bms/command/minor_command.rs
@@ -5,16 +5,16 @@ use std::time::Duration;
 
 use super::{ObjId, graphics::Argb};
 
-/// Pan value for ExWav sound effect.
-/// Range: [-10000, 10000]. -10000 is leftmost, 10000 is rightmost.
+/// Pan value for `#EXWAV` sound effect.
+/// Range: \[-10000, 10000]. -10000 is leftmost, 10000 is rightmost.
 /// Default: 0.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExWavPan(i64);
 
 impl ExWavPan {
-    /// Creates a new ExWavPan value.
-    /// Returns `None` if the value is out of range [-10000, 10000].
+    /// Creates a new [`ExWavPan`] value.
+    /// Returns `None` if the value is out of range \[-10000, 10000].
     pub fn new(value: i64) -> Option<Self> {
         (-10000..=10000).contains(&value).then_some(Self(value))
     }
@@ -38,16 +38,16 @@ impl TryFrom<i64> for ExWavPan {
     }
 }
 
-/// Volume value for ExWav sound effect.
-/// Range: [-10000, 0]. -10000 is 0%, 0 is 100%.
+/// Volume value for `#EXWAV` sound effect.
+/// Range: \[-10000, 0]. -10000 is 0%, 0 is 100%.
 /// Default: 0.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExWavVolume(i64);
 
 impl ExWavVolume {
-    /// Creates a new ExWavVolume value.
-    /// Returns `None` if the value is out of range [-10000, 0].
+    /// Creates a new [`ExWavVolume`] value.
+    /// Returns `None` if the value is out of range `[-10000, 0]`.
     pub fn new(value: i64) -> Option<Self> {
         (-10000..=0).contains(&value).then_some(Self(value))
     }
@@ -71,14 +71,14 @@ impl TryFrom<i64> for ExWavVolume {
     }
 }
 
-/// Frequency value for ExWav sound effect.
-/// Range: [100, 100000]. Unit: Hz.
+/// Frequency value for `#EXWAV` sound effect.
+/// Range: \[100, 100000]. Unit: Hz.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExWavFrequency(u64);
 
 impl ExWavFrequency {
-    /// Creates a new ExWavFrequency value.
+    /// Creates a new [`ExWavFrequency`] value.
     /// Returns `None` if the value is out of range [100, 100000].
     pub fn new(value: u64) -> Option<Self> {
         (100..=100000).contains(&value).then_some(Self(value))
@@ -108,12 +108,12 @@ pub struct StpEvent {
     pub duration: Duration,
 }
 
-/// MacBeat WAVCMD event.
+/// MacBeat `#WAVCMD` event.
 ///
-/// Used for #WAVCMD command, represents pitch/volume/time adjustment for a specific WAV object.
-/// - param: adjustment type (pitch/volume/time)
-/// - wav_index: target WAV object ID
-/// - value: adjustment value, meaning depends on param
+/// Used for `#WAVCMD` command, represents `pitch`/`volume`/`time` adjustment for a specific WAV object.
+/// - `param`: adjustment type (`pitch`/`volume`/`time`)
+/// - `wav_index`: target WAV object ID
+/// - `value`: adjustment value, meaning depends on param
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WavCmdEvent {
@@ -127,13 +127,13 @@ pub struct WavCmdEvent {
 
 /// SWBGA (Key Bind Layer Animation) event.
 ///
-/// Used for #SWBGA command, describes key-bound BGA animation.
-/// - frame_rate: frame interval (ms), e.g. 60FPS=17
-/// - total_time: total animation duration (ms), 0 means while key is held
+/// Used for `#SWBGA` command, describes key-bound BGA animation.
+/// - `frame_rate`: frame interval (ms), e.g. 60FPS=17
+/// - `total_time`: total animation duration (ms), 0 means while key is held
 /// - line: applicable key channel (e.g. 11-19, 21-29)
-/// - loop_mode: whether to loop (0: no loop, 1: loop)
-/// - argb: transparent color (A,R,G,B)
-/// - pattern: animation frame sequence (e.g. 01020304)
+/// - `loop_mode`: whether to loop (0: no loop, 1: loop)
+/// - `argb`: transparent color (A,R,G,B)
+/// - `pattern`: animation frame sequence (e.g. 01020304)
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwBgaEvent {
@@ -151,15 +151,15 @@ pub struct SwBgaEvent {
     pub pattern: String,
 }
 
-/// BM98 #ExtChr extended character customization event.
+/// BM98 `#ExtChr` extended character customization event.
 ///
-/// Used for #ExtChr command, implements custom UI element image replacement.
-/// - sprite_num: character index to replace [0-1023]
-/// - bmp_num: BMP index (hex to decimal, or -1/-257, etc.)
-/// - start_x/start_y: crop start point
-/// - end_x/end_y: crop end point
-/// - offset_x/offset_y: offset (optional)
-/// - abs_x/abs_y: absolute coordinate (optional)
+/// Used for `#ExtChr` command, implements custom UI element image replacement.
+/// - `sprite_num`: character index to replace `[0-1023]`
+/// - `bmp_num`: BMP index (hex to decimal, or `-1`/`-257`, etc.)
+/// - `start_x`/`start_y`: crop start point
+/// - `end_x`/`end_y`: crop end point
+/// - `offset_x`/`offset_y`: offset (optional)
+/// - `abs_x`/`abs_y`: absolute coordinate (optional)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtChrEvent {

--- a/src/bms/command/minor_command.rs
+++ b/src/bms/command/minor_command.rs
@@ -78,10 +78,15 @@ impl TryFrom<i64> for ExWavVolume {
 pub struct ExWavFrequency(u64);
 
 impl ExWavFrequency {
+    const MIN_FREQUENCY: u64 = 100;
+    const MAX_FREQUENCY: u64 = 100_000;
+
     /// Creates a new [`ExWavFrequency`] value.
     /// Returns `None` if the value is out of range [100, 100000].
     pub fn new(value: u64) -> Option<Self> {
-        (100..=100000).contains(&value).then_some(Self(value))
+        (Self::MIN_FREQUENCY..=Self::MAX_FREQUENCY)
+            .contains(&value)
+            .then_some(Self(value))
     }
 
     /// Returns the underlying value.
@@ -94,7 +99,7 @@ impl TryFrom<u64> for ExWavFrequency {
     type Error = u64;
 
     fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
-        Self::new(value).ok_or(value.clamp(100, 100000))
+        Self::new(value).ok_or(value.clamp(Self::MIN_FREQUENCY, Self::MAX_FREQUENCY))
     }
 }
 

--- a/src/bms/command/minor_command.rs
+++ b/src/bms/command/minor_command.rs
@@ -15,16 +15,19 @@ pub struct ExWavPan(i64);
 impl ExWavPan {
     /// Creates a new [`ExWavPan`] value.
     /// Returns `None` if the value is out of range \[-10000, 10000].
+    #[must_use]
     pub fn new(value: i64) -> Option<Self> {
         (-10000..=10000).contains(&value).then_some(Self(value))
     }
 
     /// Returns the underlying value.
+    #[must_use]
     pub fn value(self) -> i64 {
         self.0
     }
 
     /// Returns the default value (0).
+    #[must_use]
     pub const fn default() -> Self {
         Self(0)
     }
@@ -48,16 +51,19 @@ pub struct ExWavVolume(i64);
 impl ExWavVolume {
     /// Creates a new [`ExWavVolume`] value.
     /// Returns `None` if the value is out of range `[-10000, 0]`.
+    #[must_use]
     pub fn new(value: i64) -> Option<Self> {
         (-10000..=0).contains(&value).then_some(Self(value))
     }
 
     /// Returns the underlying value.
+    #[must_use]
     pub fn value(self) -> i64 {
         self.0
     }
 
     /// Returns the default value (0).
+    #[must_use]
     pub const fn default() -> Self {
         Self(0)
     }
@@ -83,6 +89,7 @@ impl ExWavFrequency {
 
     /// Creates a new [`ExWavFrequency`] value.
     /// Returns `None` if the value is out of range [100, 100000].
+    #[must_use]
     pub fn new(value: u64) -> Option<Self> {
         (Self::MIN_FREQUENCY..=Self::MAX_FREQUENCY)
             .contains(&value)
@@ -90,6 +97,7 @@ impl ExWavFrequency {
     }
 
     /// Returns the underlying value.
+    #[must_use]
     pub fn value(self) -> u64 {
         self.0
     }

--- a/src/bms/command/mixin.rs
+++ b/src/bms/command/mixin.rs
@@ -27,12 +27,12 @@ impl<T> SourceRangeMixin<T> {
     }
 
     /// Returns the wrapped content.
-    pub fn content(&self) -> &T {
+    pub const fn content(&self) -> &T {
         &self.content
     }
 
     /// Returns the wrapped content as a mutable reference.
-    pub fn content_mut(&mut self) -> &mut T {
+    pub const fn content_mut(&mut self) -> &mut T {
         &mut self.content
     }
 
@@ -42,32 +42,32 @@ impl<T> SourceRangeMixin<T> {
     }
 
     /// Returns the start index of the source span.
-    pub fn start(&self) -> usize {
+    pub const fn start(&self) -> usize {
         self.range.start
     }
 
     /// Returns the end index of the source span.
-    pub fn end(&self) -> usize {
+    pub const fn end(&self) -> usize {
         self.range.end
     }
 
     /// Returns the source range.
-    pub fn range(&self) -> &Range<usize> {
+    pub const fn range(&self) -> &Range<usize> {
         &self.range
     }
 
     /// Returns the source span as a tuple of (start, end).
-    pub fn as_span(&self) -> (usize, usize) {
+    pub const fn as_span(&self) -> (usize, usize) {
         (self.range.start, self.range.end)
     }
 
     /// Returns the length of the source span.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.range.end.saturating_sub(self.range.start)
     }
 
     /// Returns true if the source span's length is 0.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }

--- a/src/bms/command/time.rs
+++ b/src/bms/command/time.rs
@@ -31,6 +31,7 @@ impl ObjTime {
     /// Panics:
     ///
     /// When `denominator == 0`.
+    #[must_use]
     pub fn new(track: u64, numerator: u64, denominator: u64) -> Self {
         // If denominator is 0, it panics.
         assert!(denominator > 0);

--- a/src/bms/command/time.rs
+++ b/src/bms/command/time.rs
@@ -28,7 +28,7 @@ pub struct ObjTime {
 impl ObjTime {
     /// Create a new time.
     ///
-    /// Panics:
+    /// # Panics
     ///
     /// When `denominator == 0`.
     #[must_use]

--- a/src/bms/diagnostics.rs
+++ b/src/bms/diagnostics.rs
@@ -59,7 +59,7 @@ impl<'a> SimpleSource<'a> {
     /// # Parameters
     /// * `name` - Name of the source file
     /// * `text` - Complete text content of the source file
-    pub fn new(name: &'a str, text: &'a str) -> Self {
+    pub const fn new(name: &'a str, text: &'a str) -> Self {
         Self { name, text }
     }
 
@@ -67,7 +67,7 @@ impl<'a> SimpleSource<'a> {
     ///
     /// # Returns
     /// Returns the complete text content of the source file
-    pub fn text(&self) -> &'a str {
+    pub const fn text(&self) -> &'a str {
         self.text
     }
 }

--- a/src/bms/diagnostics.rs
+++ b/src/bms/diagnostics.rs
@@ -192,14 +192,14 @@ impl ToAriadne for BmsWarning {
             PlayingWarning(w) => {
                 let filename = src.name.to_string();
                 Report::build(ReportKind::Warning, (filename.clone(), 0..0))
-                    .with_message(format!("playing warning: {}", w))
+                    .with_message(format!("playing warning: {w}"))
                     .with_label(Label::new((filename, 0..0)))
                     .finish()
             }
             PlayingError(e) => {
                 let filename = src.name.to_string();
                 Report::build(ReportKind::Error, (filename.clone(), 0..0))
-                    .with_message(format!("playing error: {}", e))
+                    .with_message(format!("playing error: {e}"))
                     .with_label(Label::new((filename, 0..0)))
                     .finish()
             }

--- a/src/bms/diagnostics.rs
+++ b/src/bms/diagnostics.rs
@@ -52,7 +52,6 @@ pub struct SimpleSource<'a> {
     text: &'a str,
 }
 
-/// Implementation of SimpleSource.
 impl<'a> SimpleSource<'a> {
     /// Create a new source container instance.
     ///

--- a/src/bms/diagnostics.rs
+++ b/src/bms/diagnostics.rs
@@ -59,6 +59,7 @@ impl<'a> SimpleSource<'a> {
     /// # Parameters
     /// * `name` - Name of the source file
     /// * `text` - Complete text content of the source file
+    #[must_use]
     pub const fn new(name: &'a str, text: &'a str) -> Self {
         Self { name, text }
     }
@@ -67,6 +68,7 @@ impl<'a> SimpleSource<'a> {
     ///
     /// # Returns
     /// Returns the complete text content of the source file
+    #[must_use]
     pub const fn text(&self) -> &'a str {
         self.text
     }

--- a/src/bms/lex.rs
+++ b/src/bms/lex.rs
@@ -1,7 +1,7 @@
 //! Lexical analyzer of BMS format.
 //!
-//! Raw [String] == [lex] ==> [TokenStream] (in [BmsLexOutput]) == [parse] ==> [Bms] (in
-//! BmsParseOutput)
+//! Raw [String] == [lex] ==> [`TokenStream`] (in [`BmsLexOutput`]) == [parse] ==> [Bms] (in
+//! [`BmsParseOutput`])
 
 mod command_impl;
 mod cursor;
@@ -53,7 +53,7 @@ pub enum LexWarning {
 /// A [`LexWarning`] type with position information.
 pub type LexWarningWithRange = SourceRangeMixin<LexWarning>;
 
-/// type alias of core::result::Result<T, LexWarningWithRange>
+/// Type alias of `core::result::Result<T, LexWarningWithRange>`
 pub(crate) type Result<T> = core::result::Result<T, LexWarningWithRange>;
 
 /// Lex Parsing Results, includes tokens and warnings.

--- a/src/bms/lex.rs
+++ b/src/bms/lex.rs
@@ -109,11 +109,11 @@ impl<'a> IntoIterator for TokenRefStream<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a TokenRefStream<'a> {
-    type Item = &'a TokenWithRange<'a>;
-    type IntoIter = std::iter::Cloned<std::slice::Iter<'a, &'a TokenWithRange<'a>>>;
+impl<'a, 'b> IntoIterator for &'b TokenRefStream<'a> {
+    type Item = &'b &'a TokenWithRange<'a>;
+    type IntoIter = std::slice::Iter<'b, &'a TokenWithRange<'a>>;
     fn into_iter(self) -> Self::IntoIter {
-        self.token_refs.iter().cloned()
+        self.token_refs.iter()
     }
 }
 
@@ -158,6 +158,18 @@ impl<'a> TokenStream<'a> {
             tokens: TokenStream { tokens },
             lex_warnings: warnings,
         }
+    }
+
+    /// Makes a new iterator of tokens.
+    pub fn iter(&self) -> std::slice::Iter<'_, TokenWithRange<'a>> {
+        self.tokens.iter()
+    }
+}
+
+impl<'a> TokenRefStream<'a> {
+    /// Makes a new iterator of token references.
+    pub fn iter(&self) -> std::slice::Iter<'_, &'a TokenWithRange<'a>> {
+        self.token_refs.iter()
     }
 }
 

--- a/src/bms/lex.rs
+++ b/src/bms/lex.rs
@@ -59,6 +59,7 @@ pub(crate) type Result<T> = core::result::Result<T, LexWarningWithRange>;
 /// Lex Parsing Results, includes tokens and warnings.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[must_use]
 pub struct LexOutput<'a> {
     /// tokens
     pub tokens: TokenStream<'a>,

--- a/src/bms/lex.rs
+++ b/src/bms/lex.rs
@@ -143,7 +143,7 @@ impl<'a> TokenStream<'a> {
                 Err(warning) => {
                     warnings.push(warning);
                 }
-            };
+            }
         }
 
         let case_sensitive = tokens

--- a/src/bms/lex/cursor.rs
+++ b/src/bms/lex/cursor.rs
@@ -83,7 +83,7 @@ impl<'a> Cursor<'a> {
         // Get remaining
         let remaining_end = self.source[self.index..]
             .find('\n')
-            .unwrap_or(self.source[self.index..].len());
+            .unwrap_or_else(|| self.source[self.index..].len());
         let ret_line_end_index = if self
             .source
             .get(self.index + remaining_end - 1..=self.index + remaining_end)
@@ -106,7 +106,7 @@ impl<'a> Cursor<'a> {
         // Get remaining
         let remaining_end = self.source[self.index..]
             .find('\n')
-            .unwrap_or(self.source[self.index..].len());
+            .unwrap_or_else(|| self.source[self.index..].len());
         let ret_line_end_index = if self
             .source
             .get(self.index + remaining_end - 1..=self.index + remaining_end)

--- a/src/bms/lex/cursor.rs
+++ b/src/bms/lex/cursor.rs
@@ -13,7 +13,7 @@ pub(crate) struct Cursor<'a> {
 }
 
 impl<'a> Cursor<'a> {
-    pub(crate) fn new(source: &'a str) -> Self {
+    pub(crate) const fn new(source: &'a str) -> Self {
         Self {
             line: 1,
             col: 1,
@@ -27,7 +27,7 @@ impl<'a> Cursor<'a> {
     }
 
     fn peek_next_token_range(&self) -> std::ops::Range<usize> {
-        fn is_separator(c: char) -> bool {
+        const fn is_separator(c: char) -> bool {
             c.is_whitespace() || c == '\n'
         }
         let next_token_start = self.source[self.index..]
@@ -127,7 +127,7 @@ impl<'a> Cursor<'a> {
     }
 
     /// Returns the current byte index in the source string.
-    pub(crate) fn index(&self) -> usize {
+    pub(crate) const fn index(&self) -> usize {
         self.index
     }
 

--- a/src/bms/lex/token.rs
+++ b/src/bms/lex/token.rs
@@ -1256,7 +1256,7 @@ impl<'a> Token<'a> {
     }
 
     /// Checks if a token is a control flow token.
-    pub fn is_control_flow_token(&self) -> bool {
+    pub const fn is_control_flow_token(&self) -> bool {
         matches!(
             self,
             Token::Random(_)

--- a/src/bms/lex/token.rs
+++ b/src/bms/lex/token.rs
@@ -1283,10 +1283,10 @@ impl<'a> std::fmt::Display for Token<'a> {
             #[cfg(feature = "minor-command")]
             Token::Argb(id, argb) => write!(
                 f,
-                "#ARGB{} {},{},{},{}",
-                id, argb.alpha, argb.red, argb.green, argb.blue
+                "#ARGB{id} {},{},{},{}",
+                argb.alpha, argb.red, argb.green, argb.blue
             ),
-            Token::Artist(artist) => write!(f, "#ARTIST {}", artist),
+            Token::Artist(artist) => write!(f, "#ARTIST {artist}"),
             #[cfg(feature = "minor-command")]
             Token::AtBga {
                 id,
@@ -1312,7 +1312,7 @@ impl<'a> std::fmt::Display for Token<'a> {
             Token::BackBmp(path) => write!(f, "#BACKBMP {}", path.display()),
             Token::Base62 => write!(f, "#BASE 62"),
             #[cfg(feature = "minor-command")]
-            Token::BaseBpm(bpm) => write!(f, "#BASEBPM {}", bpm),
+            Token::BaseBpm(bpm) => write!(f, "#BASEBPM {bpm}"),
             #[cfg(feature = "minor-command")]
             Token::Bga {
                 id,
@@ -1336,25 +1336,25 @@ impl<'a> std::fmt::Display for Token<'a> {
             }
             Token::Bmp(Some(id), path) => write!(f, "#BMP{} {}", id, path.display()),
             Token::Bmp(None, path) => write!(f, "#BMP00 {}", path.display()),
-            Token::Bpm(bpm) => write!(f, "#BPM {}", bpm),
-            Token::BpmChange(id, bpm) => write!(f, "#BPM{} {}", id, bpm),
-            Token::Case(value) => write!(f, "#CASE {}", value),
+            Token::Bpm(bpm) => write!(f, "#BPM {bpm}"),
+            Token::BpmChange(id, bpm) => write!(f, "#BPM{id} {bpm}"),
+            Token::Case(value) => write!(f, "#CASE {value}"),
             #[cfg(feature = "minor-command")]
-            Token::Cdda(value) => write!(f, "#CDDA {}", value),
+            Token::Cdda(value) => write!(f, "#CDDA {value}"),
             #[cfg(feature = "minor-command")]
-            Token::ChangeOption(id, option) => write!(f, "#CHANGEOPTION{} {}", id, option),
+            Token::ChangeOption(id, option) => write!(f, "#CHANGEOPTION{id} {option}"),
             #[cfg(feature = "minor-command")]
             Token::CharFile(path) => write!(f, "#CHARFILE {}", path.display()),
-            Token::Charset(charset) => write!(f, "#CHARSET {}", charset),
-            Token::Comment(comment) => write!(f, "#COMMENT {}", comment),
+            Token::Charset(charset) => write!(f, "#CHARSET {charset}"),
+            Token::Comment(comment) => write!(f, "#COMMENT {comment}"),
             Token::Def => write!(f, "#DEF"),
-            Token::DefExRank(value) => write!(f, "#DEFEXRANK {}", value),
-            Token::Difficulty(diff) => write!(f, "#DIFFICULTY {}", diff),
+            Token::DefExRank(value) => write!(f, "#DEFEXRANK {value}"),
+            Token::Difficulty(diff) => write!(f, "#DIFFICULTY {diff}"),
             #[cfg(feature = "minor-command")]
-            Token::DivideProp(prop) => write!(f, "#DIVIDEPROP {}", prop),
+            Token::DivideProp(prop) => write!(f, "#DIVIDEPROP {prop}"),
             Token::Else => write!(f, "#ELSE"),
-            Token::ElseIf(value) => write!(f, "#ELSEIF {}", value),
-            Token::Email(email) => write!(f, "%EMAIL {}", email),
+            Token::ElseIf(value) => write!(f, "#ELSEIF {value}"),
+            Token::Email(email) => write!(f, "%EMAIL {email}"),
             Token::EndIf => write!(f, "#ENDIF"),
             Token::EndRandom => write!(f, "#ENDRANDOM"),
             Token::EndSwitch => write!(f, "#ENDSW"),
@@ -1366,9 +1366,9 @@ impl<'a> std::fmt::Display for Token<'a> {
                     ev.sprite_num, ev.bmp_num, ev.start_x, ev.start_y, ev.end_x, ev.end_y
                 )?;
                 if let (Some(offset_x), Some(offset_y)) = (ev.offset_x, ev.offset_y) {
-                    write!(f, " {} {}", offset_x, offset_y)?;
+                    write!(f, " {offset_x} {offset_y}")?;
                     if let (Some(abs_x), Some(abs_y)) = (ev.abs_x, ev.abs_y) {
-                        write!(f, " {} {}", abs_x, abs_y)?;
+                        write!(f, " {abs_x} {abs_y}")?;
                     }
                 }
                 Ok(())
@@ -1383,7 +1383,7 @@ impl<'a> std::fmt::Display for Token<'a> {
                 argb.blue,
                 path.display()
             ),
-            Token::ExRank(id, level) => write!(f, "#EXRANK{} {}", id, level),
+            Token::ExRank(id, level) => write!(f, "#EXRANK{id} {level}"),
             #[cfg(feature = "minor-command")]
             Token::ExWav {
                 id,
@@ -1392,7 +1392,7 @@ impl<'a> std::fmt::Display for Token<'a> {
                 frequency,
                 path,
             } => {
-                write!(f, "#EXWAV{}", id)?;
+                write!(f, "#EXWAV{id}")?;
                 let mut params = String::new();
                 if *pan != ExWavPan::default() {
                     params.push('p');
@@ -1406,7 +1406,7 @@ impl<'a> std::fmt::Display for Token<'a> {
                 if params.is_empty() {
                     params.push('p');
                 }
-                write!(f, " {}", params)?;
+                write!(f, " {params}")?;
                 if *pan != ExWavPan::default() {
                     write!(f, " {}", pan.value())?;
                 }
@@ -1418,8 +1418,8 @@ impl<'a> std::fmt::Display for Token<'a> {
                 }
                 write!(f, " {}", path.display())
             }
-            Token::Genre(genre) => write!(f, "#GENRE {}", genre),
-            Token::If(value) => write!(f, "#IF {}", value),
+            Token::Genre(genre) => write!(f, "#GENRE {genre}"),
+            Token::If(value) => write!(f, "#IF {value}"),
             Token::LnMode(mode) => write!(
                 f,
                 "#LNMODE {}",
@@ -1429,10 +1429,10 @@ impl<'a> std::fmt::Display for Token<'a> {
                     LnMode::Hcn => 3,
                 }
             ),
-            Token::LnObj(id) => write!(f, "#LNOBJ {}", id),
+            Token::LnObj(id) => write!(f, "#LNOBJ {id}"),
             Token::LnTypeRdm => write!(f, "#LNTYPE 1"),
             Token::LnTypeMgq => write!(f, "#LNTYPE 2"),
-            Token::Maker(maker) => write!(f, "#MAKER {}", maker),
+            Token::Maker(maker) => write!(f, "#MAKER {maker}"),
             #[cfg(feature = "minor-command")]
             Token::Materials(path) => write!(f, "#MATERIALS {}", path.display()),
             #[cfg(feature = "minor-command")]
@@ -1447,11 +1447,11 @@ impl<'a> std::fmt::Display for Token<'a> {
             #[cfg(feature = "minor-command")]
             Token::MidiFile(path) => write!(f, "#MIDIFILE {}", path.display()),
             Token::Movie(path) => write!(f, "#MOVIE {}", path.display()),
-            Token::NotACommand(content) => write!(f, "{}", content),
+            Token::NotACommand(content) => write!(f, "{content}"),
             #[cfg(feature = "minor-command")]
             Token::OctFp => write!(f, "#OCT/FP"),
             #[cfg(feature = "minor-command")]
-            Token::Option(option) => write!(f, "#OPTION {}", option),
+            Token::Option(option) => write!(f, "#OPTION {option}"),
             Token::PathWav(path) => write!(f, "#PATH_WAV {}", path.display()),
             Token::Player(mode) => write!(
                 f,
@@ -1462,7 +1462,7 @@ impl<'a> std::fmt::Display for Token<'a> {
                     PlayerMode::Double => 3,
                 }
             ),
-            Token::PlayLevel(level) => write!(f, "#PLAYLEVEL {}", level),
+            Token::PlayLevel(level) => write!(f, "#PLAYLEVEL {level}"),
             Token::PoorBga(mode) => write!(
                 f,
                 "#POORBGA {}",
@@ -1473,26 +1473,26 @@ impl<'a> std::fmt::Display for Token<'a> {
                 }
             ),
             Token::Preview(path) => write!(f, "#PREVIEW {}", path.display()),
-            Token::Random(value) => write!(f, "#RANDOM {}", value),
-            Token::Rank(level) => write!(f, "#RANK {}", level),
-            Token::Scroll(id, factor) => write!(f, "#SCROLL{} {}", id, factor),
+            Token::Random(value) => write!(f, "#RANDOM {value}"),
+            Token::Rank(level) => write!(f, "#RANK {level}"),
+            Token::Scroll(id, factor) => write!(f, "#SCROLL{id} {factor}"),
             #[cfg(feature = "minor-command")]
-            Token::Seek(id, position) => write!(f, "#SEEK{} {}", id, position),
-            Token::SetRandom(value) => write!(f, "#SETRANDOM {}", value),
-            Token::SetSwitch(value) => write!(f, "#SETSWITCH {}", value),
+            Token::Seek(id, position) => write!(f, "#SEEK{id} {position}"),
+            Token::SetRandom(value) => write!(f, "#SETRANDOM {value}"),
+            Token::SetSwitch(value) => write!(f, "#SETSWITCH {value}"),
             Token::Skip => write!(f, "#SKIP"),
-            Token::Speed(id, factor) => write!(f, "#SPEED{} {}", id, factor),
+            Token::Speed(id, factor) => write!(f, "#SPEED{id} {factor}"),
             Token::StageFile(path) => write!(f, "#STAGEFILE {}", path.display()),
-            Token::Stop(id, beats) => write!(f, "#STOP{} {}", id, beats),
+            Token::Stop(id, beats) => write!(f, "#STOP{id} {beats}"),
             #[cfg(feature = "minor-command")]
             Token::Stp(ev) => {
                 let measure = ev.time.track.0;
                 let pos = (ev.time.numerator * 1000 / ev.time.denominator) as u16;
                 let ms = ev.duration.as_millis() as u32;
-                write!(f, "#STP {:03}.{:03} {}", measure, pos, ms)
+                write!(f, "#STP {measure:03}.{pos:03} {ms}")
             }
-            Token::SubArtist(sub_artist) => write!(f, "#SUBARTIST {}", sub_artist),
-            Token::SubTitle(subtitle) => write!(f, "#SUBTITLE {}", subtitle),
+            Token::SubArtist(sub_artist) => write!(f, "#SUBARTIST {sub_artist}"),
+            Token::SubTitle(subtitle) => write!(f, "#SUBTITLE {subtitle}"),
             #[cfg(feature = "minor-command")]
             Token::SwBga(id, ev) => {
                 write!(
@@ -1510,19 +1510,19 @@ impl<'a> std::fmt::Display for Token<'a> {
                     ev.pattern
                 )
             }
-            Token::Switch(value) => write!(f, "#SWITCH {}", value),
-            Token::Text(id, text) => write!(f, "#TEXT{} {}", id, text),
-            Token::Title(title) => write!(f, "#TITLE {}", title),
-            Token::Total(total) => write!(f, "#TOTAL {}", total),
-            Token::UnknownCommand(cmd) => write!(f, "{}", cmd),
-            Token::Url(url) => write!(f, "%URL {}", url),
+            Token::Switch(value) => write!(f, "#SWITCH {value}"),
+            Token::Text(id, text) => write!(f, "#TEXT{id} {text}"),
+            Token::Title(title) => write!(f, "#TITLE {title}"),
+            Token::Total(total) => write!(f, "#TOTAL {total}"),
+            Token::UnknownCommand(cmd) => write!(f, "{cmd}"),
+            Token::Url(url) => write!(f, "%URL {url}"),
             #[cfg(feature = "minor-command")]
-            Token::VideoColors(colors) => write!(f, "#VIDEOCOLORS {}", colors),
+            Token::VideoColors(colors) => write!(f, "#VIDEOCOLORS {colors}"),
             #[cfg(feature = "minor-command")]
-            Token::VideoDly(delay) => write!(f, "#VIDEODLY {}", delay),
+            Token::VideoDly(delay) => write!(f, "#VIDEODLY {delay}"),
             Token::VideoFile(path) => write!(f, "#VIDEOFILE {}", path.display()),
             #[cfg(feature = "minor-command")]
-            Token::VideoFs(fps) => write!(f, "#VIDEOF/S {}", fps),
+            Token::VideoFs(fps) => write!(f, "#VIDEOF/S {fps}"),
             Token::VolWav(volume) => write!(f, "#VOLWAV {}", volume.relative_percent),
             Token::Wav(id, path) => write!(f, "#WAV{} {}", id, path.display()),
             #[cfg(feature = "minor-command")]

--- a/src/bms/lex/token.rs
+++ b/src/bms/lex/token.rs
@@ -664,7 +664,7 @@ impl<'a> Token<'a> {
                                 .map_err(|_| c.make_err_expected_token("integer"))?;
                             pan = Some(ExWavPan::try_from(pan_value).map_err(|_| {
                                 c.make_err_expected_token("pan value out of range [-10000, 10000]")
-                            })?)
+                            })?);
                         }
                         b'v' => {
                             let volume_value: i64 = c
@@ -674,7 +674,7 @@ impl<'a> Token<'a> {
                                 .map_err(|_| c.make_err_expected_token("integer"))?;
                             volume = Some(ExWavVolume::try_from(volume_value).map_err(|_| {
                                 c.make_err_expected_token("volume value out of range [-10000, 0]")
-                            })?)
+                            })?);
                         }
                         b'f' => {
                             let frequency_value: u64 = c
@@ -687,7 +687,7 @@ impl<'a> Token<'a> {
                                     c.make_err_expected_token(
                                         "frequency value out of range [100, 100000]",
                                     )
-                                })?)
+                                })?);
                         }
                         _ => return Err(c.make_err_expected_token("expected p, v or f")),
                     }

--- a/src/bms/lex/token.rs
+++ b/src/bms/lex/token.rs
@@ -1277,7 +1277,7 @@ impl<'a> Token<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for Token<'a> {
+impl std::fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             #[cfg(feature = "minor-command")]
@@ -1443,7 +1443,7 @@ impl<'a> std::fmt::Display for Token<'a> {
                 track,
                 channel,
                 message,
-            } => fmt_message(f, track, channel, message),
+            } => fmt_message(f, *track, *channel, message),
             #[cfg(feature = "minor-command")]
             Token::MidiFile(path) => write!(f, "#MIDIFILE {}", path.display()),
             Token::Movie(path) => write!(f, "#MOVIE {}", path.display()),
@@ -1542,8 +1542,8 @@ impl<'a> std::fmt::Display for Token<'a> {
 
 fn fmt_message(
     f: &mut std::fmt::Formatter<'_>,
-    track: &Track,
-    channel: &Channel,
+    track: Track,
+    channel: Channel,
     message: &str,
 ) -> std::fmt::Result {
     // Convert channel back to string representation

--- a/src/bms/lex/token.rs
+++ b/src/bms/lex/token.rs
@@ -1256,6 +1256,7 @@ impl<'a> Token<'a> {
     }
 
     /// Checks if a token is a control flow token.
+    #[must_use]
     pub const fn is_control_flow_token(&self) -> bool {
         matches!(
             self,

--- a/src/bms/lex/token.rs
+++ b/src/bms/lex/token.rs
@@ -130,11 +130,11 @@ pub enum Token<'a> {
     ElseIf(BigUint),
     /// `%EMAIL [string]`. The email address of this score file author.
     Email(&'a str),
-    /// `#ENDIF`. Closes the if scope. See [Token::If].
+    /// `#ENDIF`. Closes the if scope. See [`Token::If`].
     EndIf,
-    /// `#ENDRANDOM`. Closes the random scope. See [Token::Random].
+    /// `#ENDRANDOM`. Closes the random scope. See [`Token::Random`].
     EndRandom,
-    /// `#ENDSW`. Closes the random scope. See [Token::Switch].
+    /// `#ENDSW`. Closes the random scope. See [`Token::Switch`].
     EndSwitch,
     /// `#ExtChr SpriteNum BMPNum startX startY endX endY [offsetX offsetY [x y]]` BM98 extended character customization.
     #[cfg(feature = "minor-command")]

--- a/src/bms/parse.rs
+++ b/src/bms/parse.rs
@@ -76,7 +76,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
         token_iter: impl IntoIterator<Item = &'a TokenWithRange<'a>>,
         mut prompt_handler: impl PromptHandler,
     ) -> ParseOutput<T> {
-        let mut bms = Bms::default();
+        let mut bms = Self::default();
         let mut parse_warnings = vec![];
         for token in token_iter {
             if let Err(error) = bms.parse(token, &mut prompt_handler) {
@@ -120,7 +120,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
         let ParseOutput {
             bms,
             parse_warnings,
-        } = Bms::from_token_stream(token_refs, prompt_handler);
+        } = Self::from_token_stream(token_refs, prompt_handler);
         ParseOutputWithAst {
             bms,
             ast_build_warnings,

--- a/src/bms/parse.rs
+++ b/src/bms/parse.rs
@@ -63,6 +63,7 @@ pub type ParseWarningWithRange = SourceRangeMixin<ParseWarning>;
 /// Bms Parse Output
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[must_use]
 pub struct ParseOutput<T: KeyLayoutMapper = KeyLayoutBeat> {
     /// The output Bms.
     pub bms: Bms<T>,
@@ -94,6 +95,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
 /// Bms Parse Output with AST
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[must_use]
 pub struct ParseOutputWithAst<T: KeyLayoutMapper = KeyLayoutBeat> {
     /// The output Bms.
     pub bms: Bms<T>,

--- a/src/bms/parse.rs
+++ b/src/bms/parse.rs
@@ -61,7 +61,7 @@ pub(crate) type Result<T> = core::result::Result<T, ParseWarning>;
 pub type ParseWarningWithRange = SourceRangeMixin<ParseWarning>;
 
 /// Bms Parse Output
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ParseOutput<T: KeyLayoutMapper = KeyLayoutBeat> {
     /// The output Bms.
@@ -92,7 +92,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
 }
 
 /// Bms Parse Output with AST
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ParseOutputWithAst<T: KeyLayoutMapper = KeyLayoutBeat> {
     /// The output Bms.

--- a/src/bms/parse.rs
+++ b/src/bms/parse.rs
@@ -1,7 +1,7 @@
-//! Parsing Bms from [TokenStream].
+//! Parsing Bms from [`TokenStream`].
 //!
-//! Raw [String] == [lex] ==> [TokenStream] (in [BmsLexOutput]) == [parse] ==> [Bms] (in
-//! BmsParseOutput)
+//! Raw [String] == [lex] ==> [`TokenStream`] (in [`BmsLexOutput`]) == [parse] ==> [Bms] (in
+//! [`BmsParseOutput`])
 
 pub mod check_playing;
 pub mod model;
@@ -54,7 +54,7 @@ pub enum ParseWarning {
     UnexpectedControlFlow,
 }
 
-/// type alias of core::result::Result<T, ParseWarning>
+/// Type alias of `core::result::Result<T, ParseWarning>`
 pub(crate) type Result<T> = core::result::Result<T, ParseWarning>;
 
 /// A parse warning with position information.

--- a/src/bms/parse/check_playing.rs
+++ b/src/bms/parse/check_playing.rs
@@ -44,6 +44,7 @@ pub enum PlayingError {
 /// Output of checking for playing warnings and errors.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[must_use]
 pub struct PlayingCheckOutput {
     /// List of [`PlayingWarning`]s.
     pub playing_warnings: Vec<PlayingWarning>,

--- a/src/bms/parse/check_playing.rs
+++ b/src/bms/parse/check_playing.rs
@@ -42,7 +42,7 @@ pub enum PlayingError {
 }
 
 /// Output of checking for playing warnings and errors.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PlayingCheckOutput {
     /// List of [`PlayingWarning`]s.

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -1382,7 +1382,7 @@ impl Arrangers {
 
 impl Graphics {
     /// Returns the bga change objects.
-    pub fn bga_changes(&self) -> &BTreeMap<ObjTime, BgaObj> {
+    pub const fn bga_changes(&self) -> &BTreeMap<ObjTime, BgaObj> {
         &self.bga_changes
     }
 
@@ -1489,7 +1489,7 @@ impl Notes {
     }
 
     /// Returns all the bgms in the score.
-    pub fn bgms(&self) -> &BTreeMap<ObjTime, Vec<ObjId>> {
+    pub const fn bgms(&self) -> &BTreeMap<ObjTime, Vec<ObjId>> {
         &self.bgms
     }
 

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -53,7 +53,7 @@ use super::{
 };
 
 /// A score data of BMS format.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bms<T: KeyLayoutMapper = KeyLayoutBeat> {
     /// The header data in the score.
@@ -88,7 +88,7 @@ impl<T: KeyLayoutMapper> Default for Bms<T> {
 
 /// A header of the score, including the information that is usually used in music selection.
 /// Parsed from [`TokenStream`](crate::lex::Token::TokenStream).
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Header {
     /// The play style of the score.
@@ -151,7 +151,7 @@ pub struct Header {
 /// Stores the original scope-defines like `#WAVXX`. Using HashMap.
 /// Only stores the original scope-defines, not the parsed ones.
 /// Only stores which affects playing.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScopeDefines {
     /// BPM change definitions, indexed by ObjId. #BPM[01-ZZ]
@@ -185,7 +185,7 @@ pub struct ScopeDefines {
 }
 
 /// The objects that arrange the playing panel running or showing.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Arrangers {
     /// Section length change events, indexed by track. #SECLEN
@@ -214,7 +214,7 @@ pub struct Arrangers {
 }
 
 /// The playable objects set for querying by lane or time.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Notes {
     /// The path to override the base path of the WAV file path.
@@ -256,7 +256,7 @@ pub struct Notes {
 }
 
 /// The graphics objects that are used in the score.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Graphics {
     /// The path of the background video. The video should be started the playing from the section 000.
@@ -296,7 +296,7 @@ pub struct Graphics {
 }
 
 /// The other objects that are used in the score. May be arranged in play.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Others {
     /// The message for overriding options of some BMS player.

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -1375,7 +1375,7 @@ impl Arrangers {
             .and_modify(|existing| {
                 existing.duration = &existing.duration + &stop.duration;
             })
-            .or_insert_with(|| stop.clone());
+            .or_insert_with(|| stop);
     }
 }
 
@@ -1509,11 +1509,14 @@ impl Notes {
 
     /// Adds the new note object to the notes.
     pub fn push_note(&mut self, note: Obj) {
-        self.objs.entry(note.obj).or_default().push(note.clone());
+        let entry_key = (note.side, note.key);
+        let offset = note.offset;
+        let obj = note.obj;
+        self.objs.entry(obj).or_default().push(note);
         self.ids_by_key
-            .entry((note.side, note.key))
+            .entry(entry_key)
             .or_default()
-            .insert(note.offset, note.obj);
+            .insert(offset, obj);
     }
 
     /// Removes the latest note from the notes.

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -1839,7 +1839,7 @@ fn volume_from_message(track: Track, message: &'_ str) -> impl Iterator<Item = (
 impl<T: KeyLayoutMapper> Bms<T> {
     /// One-way converting ([`crate::bms::command::channel::PlayerSide`], [`crate::bms::command::channel::Key`]) with [`KeyLayoutConverter`].
     pub fn convert_key(&mut self, mut converter: impl KeyLayoutConverter) {
-        for (_, objs) in self.notes.objs.iter_mut() {
+        for objs in self.notes.objs.values_mut() {
             for Obj {
                 side, kind, key, ..
             } in objs.iter_mut()

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -732,12 +732,12 @@ impl<T: KeyLayoutMapper> Bms<T> {
             } => {
                 let denominator = message.len() as u64 / 2;
                 for (i, (c1, c2)) in message.chars().tuples().enumerate() {
-                    let bpm = c1.to_digit(16).ok_or(ParseWarning::SyntaxError(format!(
-                        "Invalid hex digit: {c1}",
-                    )))? * 16
-                        + c2.to_digit(16).ok_or(ParseWarning::SyntaxError(format!(
-                            "Invalid hex digit: {c2}",
-                        )))?;
+                    let bpm = c1.to_digit(16).ok_or_else(|| {
+                        ParseWarning::SyntaxError(format!("Invalid hex digit: {c1}",))
+                    })? * 16
+                        + c2.to_digit(16).ok_or_else(|| {
+                            ParseWarning::SyntaxError(format!("Invalid hex digit: {c2}",))
+                        })?;
                     if bpm == 0 {
                         continue;
                     }
@@ -1105,12 +1105,11 @@ impl<T: KeyLayoutMapper> Bms<T> {
                             "expected preceding object for #LNOBJ {end_id:?}",
                         ))
                     })?;
-                let mut begin_note =
-                    self.notes
-                        .remove_latest_note(begin_id)
-                        .ok_or(ParseWarning::SyntaxError(format!(
-                            "Cannot find begin note for LNOBJ {end_id:?}"
-                        )))?;
+                let mut begin_note = self.notes.remove_latest_note(begin_id).ok_or_else(|| {
+                    ParseWarning::SyntaxError(format!(
+                        "Cannot find begin note for LNOBJ {end_id:?}"
+                    ))
+                })?;
                 begin_note.kind = NoteKind::Long;
                 end_note.kind = NoteKind::Long;
                 self.notes.push_note(begin_note);
@@ -1376,7 +1375,7 @@ impl Arrangers {
             .and_modify(|existing| {
                 existing.duration = &existing.duration + &stop.duration;
             })
-            .or_insert(stop.clone());
+            .or_insert_with(|| stop.clone());
     }
 }
 

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -863,7 +863,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
                         return Err(ParseWarning::UndefinedObject(obj));
                     }
                     let layer = BgaLayer::from_channel(*channel)
-                        .unwrap_or_else(|| panic!("Invalid channel for BgaLayer: {:?}", channel));
+                        .unwrap_or_else(|| panic!("Invalid channel for BgaLayer: {channel:?}"));
                     self.graphics.push_bga_change(
                         BgaObj {
                             time,
@@ -915,7 +915,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
             } => {
                 for (time, opacity_value) in opacity_from_message(*track, message) {
                     let layer = BgaLayer::from_channel(*channel)
-                        .unwrap_or_else(|| panic!("Invalid channel for BgaLayer: {:?}", channel));
+                        .unwrap_or_else(|| panic!("Invalid channel for BgaLayer: {channel:?}"));
                     self.graphics.push_bga_opacity_change(
                         BgaOpacityObj {
                             time,
@@ -969,7 +969,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
             } => {
                 for (time, argb_id) in ids_from_message(*track, message) {
                     let layer = BgaLayer::from_channel(*channel)
-                        .unwrap_or_else(|| panic!("Invalid channel for BgaLayer: {:?}", channel));
+                        .unwrap_or_else(|| panic!("Invalid channel for BgaLayer: {channel:?}"));
                     let argb = self
                         .scope_defines
                         .argb_defs

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -149,26 +149,26 @@ pub struct Header {
     pub movie: Option<PathBuf>,
 }
 
-/// Stores the original scope-defines like `#WAVXX`. Using HashMap.
+/// Stores the original scope-defines like `#WAVXX`. Using [`HashMap`].
 /// Only stores the original scope-defines, not the parsed ones.
 /// Only stores which affects playing.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScopeDefines {
-    /// BPM change definitions, indexed by ObjId. #BPM[01-ZZ]
+    /// BPM change definitions, indexed by [`ObjId`]. `#BPM[01-ZZ]`
     pub bpm_defs: HashMap<ObjId, Decimal>,
-    /// Stop definitions, indexed by ObjId. #STOP[01-ZZ]
+    /// Stop definitions, indexed by [`ObjId`]. `#STOP[01-ZZ]`
     pub stop_defs: HashMap<ObjId, Decimal>,
-    /// Scroll speed change definitions, indexed by ObjId. #SCROLL[01-ZZ]
+    /// Scroll speed change definitions, indexed by [`ObjId`]. `#SCROLL[01-ZZ]`
     pub scroll_defs: HashMap<ObjId, Decimal>,
-    /// Spacing change definitions, indexed by ObjId. #SPEED[01-ZZ]
+    /// Spacing change definitions, indexed by [`ObjId`]. `#SPEED[01-ZZ]`
     pub speed_defs: HashMap<ObjId, Decimal>,
     /// Storage for #EXRANK definitions
     pub exrank_defs: HashMap<ObjId, ExRankDef>,
     /// Storage for #EXWAV definitions
     #[cfg(feature = "minor-command")]
     pub exwav_defs: HashMap<ObjId, ExWavDef>,
-    /// WAVCMD events, indexed by wav_index. #WAVCMD
+    /// WAVCMD events, indexed by `wav_index`. `#WAVCMD`
     #[cfg(feature = "minor-command")]
     pub wavcmd_events: HashMap<ObjId, WavCmdEvent>,
     /// Storage for #@BGA definitions
@@ -177,10 +177,10 @@ pub struct ScopeDefines {
     /// Storage for #BGA definitions
     #[cfg(feature = "minor-command")]
     pub bga_defs: HashMap<ObjId, BgaDef>,
-    /// SWBGA events, indexed by ObjId. #SWBGA
+    /// SWBGA events, indexed by [`ObjId`]. `#SWBGA`
     #[cfg(feature = "minor-command")]
     pub swbga_events: HashMap<ObjId, SwBgaEvent>,
-    /// ARGB definitions, indexed by ObjId. #ARGB
+    /// ARGB definitions, indexed by [`ObjId`]. `#ARGB`
     #[cfg(feature = "minor-command")]
     pub argb_defs: HashMap<ObjId, Argb>,
 }
@@ -189,27 +189,27 @@ pub struct ScopeDefines {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Arrangers {
-    /// Section length change events, indexed by track. #SECLEN
+    /// Section length change events, indexed by track. `#SECLEN`
     pub section_len_changes: BTreeMap<Track, SectionLenChangeObj>,
     /// The initial BPM of the score.
     pub bpm: Option<Decimal>,
     /// The BPMs corresponding to the id of the BPM change object.
-    /// BPM change events, indexed by time. #BPM[01-ZZ] in message
+    /// BPM change events, indexed by time. `#BPM[01-ZZ]` in message
     pub bpm_changes: BTreeMap<ObjTime, BpmChangeObj>,
-    /// Record of used BPM change ids from #BPMxx messages, for validity checks.
+    /// Record of used BPM change ids from `#BPMxx` messages, for validity checks.
     pub bpm_change_ids_used: HashSet<ObjId>,
     /// Stop lengths by stop object id.
     pub stops: BTreeMap<ObjTime, StopObj>,
-    /// Record of used STOP ids from #STOPxx messages, for validity checks.
+    /// Record of used STOP ids from `#STOPxx` messages, for validity checks.
     pub stop_ids_used: HashSet<ObjId>,
     /// The scrolling factors corresponding to the id of the scroll speed change object.
     pub scrolling_factor_changes: BTreeMap<ObjTime, ScrollingFactorObj>,
     /// The spacing factors corresponding to the id of the spacing change object.
     pub speed_factor_changes: BTreeMap<ObjTime, SpeedObj>,
-    /// bemaniaDX STP events, indexed by ObjTime. #STP
+    /// bemaniaDX STP events, indexed by [`ObjTime`]. `#STP`
     #[cfg(feature = "minor-command")]
     pub stp_events: BTreeMap<ObjTime, StpEvent>,
-    /// #BASEBPM for LR. Replaced by bpm match in LR2.
+    /// `#BASEBPM` for LR. Replaced by bpm match in LR2.
     #[cfg(feature = "minor-command")]
     pub base_bpm: Option<Decimal>,
 }
@@ -224,9 +224,9 @@ pub struct Notes {
     /// The WAV file paths corresponding to the id of the note object.
     pub wav_files: HashMap<ObjId, PathBuf>,
     // objects stored in obj is sorted, so it can be searched by bisection method
-    /// BGM objects, indexed by time. #XXX01:ZZ... (BGM placement)
+    /// BGM objects, indexed by time. `#XXX01:ZZ...` (BGM placement)
     pub bgms: BTreeMap<ObjTime, Vec<ObjId>>,
-    /// All note objects, indexed by ObjId. #XXXYY:ZZ... (note placement)
+    /// All note objects, indexed by [`ObjId`]. `#XXXYY:ZZ...` (note placement)
     pub objs: HashMap<ObjId, Vec<Obj>>,
     /// Index for fast key lookup. Used for LN/landmine logic.
     /// Maps each ([`PlayerSide`], [`Key`]) pair to a sorted map of times and [`ObjId`]s for efficient note lookup.
@@ -307,16 +307,16 @@ pub struct Others {
     /// In octave mode, the chart may have different note arrangements or gameplay mechanics.
     #[cfg(feature = "minor-command")]
     pub is_octave: bool,
-    /// CDDA events, indexed by value. #CDDA
+    /// CDDA events, indexed by value. `#CDDA`
     #[cfg(feature = "minor-command")]
     pub cdda: Vec<BigUint>,
-    /// Seek events, indexed by ObjId. #SEEK
+    /// Seek events, indexed by [`ObjId`]. `#SEEK`
     #[cfg(feature = "minor-command")]
     pub seek_events: HashMap<ObjId, Decimal>,
-    /// ExtChr events. #ExtChr
+    /// Extended-character events. `#ExtChr`
     #[cfg(feature = "minor-command")]
     pub extchr_events: Vec<ExtChrEvent>,
-    /// Storage for #TEXT definitions
+    /// Storage for `#TEXT` definitions
     /// The texts corresponding to the id of the text object.
     pub texts: HashMap<ObjId, String>,
     /// The option messages corresponding to the id of the change option object.

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -1230,6 +1230,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
     }
 
     /// Calculates a required resolution to convert the notes time into pulses, which split one quarter note evenly.
+    #[must_use]
     pub fn resolution_for_pulses(&self) -> u64 {
         use num::Integer;
 
@@ -1381,6 +1382,7 @@ impl Arrangers {
 
 impl Graphics {
     /// Returns the bga change objects.
+    #[must_use]
     pub const fn bga_changes(&self) -> &BTreeMap<ObjTime, BgaObj> {
         &self.bga_changes
     }
@@ -1478,6 +1480,7 @@ impl Graphics {
 
 impl Notes {
     /// Converts into the notes sorted by time.
+    #[must_use]
     pub fn into_all_notes(self) -> Vec<Obj> {
         self.objs.into_values().flatten().sorted().collect()
     }
@@ -1488,11 +1491,13 @@ impl Notes {
     }
 
     /// Returns all the bgms in the score.
+    #[must_use]
     pub const fn bgms(&self) -> &BTreeMap<ObjTime, Vec<ObjId>> {
         &self.bgms
     }
 
     /// Finds next object on the key `Key` from the time `ObjTime`.
+    #[must_use]
     pub fn next_obj_by_key(&self, side: PlayerSide, key: Key, time: ObjTime) -> Option<&Obj> {
         self.ids_by_key
             .get(&(side, key))?
@@ -1555,6 +1560,7 @@ impl Notes {
     /// Gets the time of last BGM object.
     ///
     /// You can't use this to find the length of music. Because this doesn't consider that the length of sound. And visible notes may ring after all BGMs.
+    #[must_use]
     pub fn last_bgm_time(&self) -> Option<ObjTime> {
         self.bgms.last_key_value().map(|(time, _)| time).cloned()
     }

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -846,7 +846,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
                     self.arrangers.push_stop(StopObj {
                         time,
                         duration: duration.clone(),
-                    })
+                    });
                 }
             }
             Token::Message {
@@ -881,7 +881,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
                 message,
             } => {
                 for (time, obj) in ids_from_message(*track, message) {
-                    self.notes.bgms.entry(time).or_default().push(obj)
+                    self.notes.bgms.entry(time).or_default().push(obj);
                 }
             }
             Token::Message {
@@ -1138,7 +1138,7 @@ impl<T: KeyLayoutMapper> Bms<T> {
             Token::Cdda(big_uint) => self.others.cdda.push(big_uint.clone()),
             #[cfg(feature = "minor-command")]
             Token::BaseBpm(generic_decimal) => {
-                self.arrangers.base_bpm = Some(generic_decimal.clone())
+                self.arrangers.base_bpm = Some(generic_decimal.clone());
             }
             Token::NotACommand(line) => self.others.non_command_lines.push(line.to_string()),
             Token::UnknownCommand(line) => self.others.unknown_command_lines.push(line.to_string()),

--- a/src/bms/parse/model.rs
+++ b/src/bms/parse/model.rs
@@ -8,6 +8,7 @@ use std::{
     cmp::Reverse,
     collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
+    marker::PhantomData,
     ops::Bound,
     path::PathBuf,
     str::FromStr,
@@ -81,7 +82,7 @@ impl<T: KeyLayoutMapper> Default for Bms<T> {
             notes: Default::default(),
             graphics: Default::default(),
             others: Default::default(),
-            _phantom: Default::default(),
+            _phantom: PhantomData,
         }
     }
 }

--- a/src/bms/parse/model/obj.rs
+++ b/src/bms/parse/model/obj.rs
@@ -184,7 +184,7 @@ pub enum BgaLayer {
 
 impl BgaLayer {
     /// Convert a [`crate::bms::command::channel::Channel`] to a [`BgaLayer`].
-    pub fn from_channel(channel: Channel) -> Option<Self> {
+    pub const fn from_channel(channel: Channel) -> Option<Self> {
         match channel {
             Channel::BgaBase => Some(BgaLayer::Base),
             #[cfg(feature = "minor-command")]
@@ -203,7 +203,7 @@ impl BgaLayer {
     }
 
     /// Convert a [`BgaLayer`] to a [`crate::bms::command::channel::Channel`].
-    pub fn to_channel(self) -> Channel {
+    pub const fn to_channel(self) -> Channel {
         match self {
             BgaLayer::Base => Channel::BgaBase,
             BgaLayer::Overlay => Channel::BgaLayer,

--- a/src/bms/parse/model/obj.rs
+++ b/src/bms/parse/model/obj.rs
@@ -186,18 +186,18 @@ impl BgaLayer {
     /// Convert a [`crate::bms::command::channel::Channel`] to a [`BgaLayer`].
     pub const fn from_channel(channel: Channel) -> Option<Self> {
         match channel {
-            Channel::BgaBase => Some(BgaLayer::Base),
+            Channel::BgaBase => Some(Self::Base),
             #[cfg(feature = "minor-command")]
-            Channel::BgaBaseArgb | Channel::BgaBaseOpacity => Some(BgaLayer::Base),
-            Channel::BgaLayer => Some(BgaLayer::Overlay),
+            Channel::BgaBaseArgb | Channel::BgaBaseOpacity => Some(Self::Base),
+            Channel::BgaLayer => Some(Self::Overlay),
             #[cfg(feature = "minor-command")]
-            Channel::BgaLayerArgb | Channel::BgaLayerOpacity => Some(BgaLayer::Overlay),
-            Channel::BgaLayer2 => Some(BgaLayer::Overlay2),
+            Channel::BgaLayerArgb | Channel::BgaLayerOpacity => Some(Self::Overlay),
+            Channel::BgaLayer2 => Some(Self::Overlay2),
             #[cfg(feature = "minor-command")]
-            Channel::BgaLayer2Argb | Channel::BgaLayer2Opacity => Some(BgaLayer::Overlay2),
-            Channel::BgaPoor => Some(BgaLayer::Poor),
+            Channel::BgaLayer2Argb | Channel::BgaLayer2Opacity => Some(Self::Overlay2),
+            Channel::BgaPoor => Some(Self::Poor),
             #[cfg(feature = "minor-command")]
-            Channel::BgaPoorArgb | Channel::BgaPoorOpacity => Some(BgaLayer::Poor),
+            Channel::BgaPoorArgb | Channel::BgaPoorOpacity => Some(Self::Poor),
             _ => None,
         }
     }
@@ -205,10 +205,10 @@ impl BgaLayer {
     /// Convert a [`BgaLayer`] to a [`crate::bms::command::channel::Channel`].
     pub const fn to_channel(self) -> Channel {
         match self {
-            BgaLayer::Base => Channel::BgaBase,
-            BgaLayer::Overlay => Channel::BgaLayer,
-            BgaLayer::Overlay2 => Channel::BgaLayer2,
-            BgaLayer::Poor => Channel::BgaPoor,
+            Self::Base => Channel::BgaBase,
+            Self::Overlay => Channel::BgaLayer,
+            Self::Overlay2 => Channel::BgaLayer2,
+            Self::Poor => Channel::BgaPoor,
         }
     }
 }

--- a/src/bms/parse/model/obj.rs
+++ b/src/bms/parse/model/obj.rs
@@ -184,6 +184,7 @@ pub enum BgaLayer {
 
 impl BgaLayer {
     /// Convert a [`crate::bms::command::channel::Channel`] to a [`BgaLayer`].
+    #[must_use]
     pub const fn from_channel(channel: Channel) -> Option<Self> {
         match channel {
             Channel::BgaBase => Some(Self::Base),
@@ -203,6 +204,7 @@ impl BgaLayer {
     }
 
     /// Convert a [`BgaLayer`] to a [`crate::bms::command::channel::Channel`].
+    #[must_use]
     pub const fn to_channel(self) -> Channel {
         match self {
             Self::Base => Channel::BgaBase,

--- a/src/bms/parse/model/obj.rs
+++ b/src/bms/parse/model/obj.rs
@@ -17,7 +17,7 @@ use crate::bms::command::{graphics::Argb, minor_command::SwBgaEvent};
 pub struct Obj {
     /// The time offset in the track.
     pub offset: ObjTime,
-    /// THe note kind of the the object.
+    /// The note kind of the the object.
     pub kind: NoteKind,
     /// The side of the player.
     pub side: PlayerSide,

--- a/src/bms/parse/prompt.rs
+++ b/src/bms/parse/prompt.rs
@@ -168,10 +168,10 @@ pub enum DefDuplication<'a> {
         /// Incoming definition.
         newer: &'a Argb,
     },
-    /// WAVCMD event is duplicated.
+    /// `WAVCMD` event is duplicated.
     #[cfg(feature = "minor-command")]
     WavCmdEvent {
-        /// Duplicated WAVCMD event wav_index.
+        /// Duplicated `WAVCMD` event `wav_index`.
         wav_index: ObjId,
         /// Existing definition.
         older: &'a WavCmdEvent,

--- a/src/bms/parse/prompt.rs
+++ b/src/bms/parse/prompt.rs
@@ -366,13 +366,13 @@ pub enum DuplicationWorkaround {
 impl DuplicationWorkaround {
     pub(crate) fn apply_def<T>(self, target: &mut T, newer: T, id: ObjId) -> Result<()> {
         match self {
-            DuplicationWorkaround::UseOlder => Ok(()),
-            DuplicationWorkaround::UseNewer => {
+            Self::UseOlder => Ok(()),
+            Self::UseNewer => {
                 *target = newer;
                 Ok(())
             }
-            DuplicationWorkaround::WarnAndUseOlder => Err(ParseWarning::DuplicatingDef(id)),
-            DuplicationWorkaround::WarnAndUseNewer => {
+            Self::WarnAndUseOlder => Err(ParseWarning::DuplicatingDef(id)),
+            Self::WarnAndUseNewer => {
                 *target = newer;
                 Err(ParseWarning::DuplicatingDef(id))
             }
@@ -387,15 +387,13 @@ impl DuplicationWorkaround {
         channel: Channel,
     ) -> Result<()> {
         match self {
-            DuplicationWorkaround::UseOlder => Ok(()),
-            DuplicationWorkaround::UseNewer => {
+            Self::UseOlder => Ok(()),
+            Self::UseNewer => {
                 *target = newer;
                 Ok(())
             }
-            DuplicationWorkaround::WarnAndUseOlder => {
-                Err(ParseWarning::DuplicatingTrackObj(track, channel))
-            }
-            DuplicationWorkaround::WarnAndUseNewer => {
+            Self::WarnAndUseOlder => Err(ParseWarning::DuplicatingTrackObj(track, channel)),
+            Self::WarnAndUseNewer => {
                 *target = newer;
                 Err(ParseWarning::DuplicatingTrackObj(track, channel))
             }
@@ -410,15 +408,13 @@ impl DuplicationWorkaround {
         channel: Channel,
     ) -> Result<()> {
         match self {
-            DuplicationWorkaround::UseOlder => Ok(()),
-            DuplicationWorkaround::UseNewer => {
+            Self::UseOlder => Ok(()),
+            Self::UseNewer => {
                 *target = newer;
                 Ok(())
             }
-            DuplicationWorkaround::WarnAndUseOlder => {
-                Err(ParseWarning::DuplicatingChannelObj(time, channel))
-            }
-            DuplicationWorkaround::WarnAndUseNewer => {
+            Self::WarnAndUseOlder => Err(ParseWarning::DuplicatingChannelObj(time, channel)),
+            Self::WarnAndUseNewer => {
                 *target = newer;
                 Err(ParseWarning::DuplicatingChannelObj(time, channel))
             }

--- a/src/bms/parse/validity.rs
+++ b/src/bms/parse/validity.rs
@@ -198,17 +198,6 @@ impl Bms {
                 .filter(|o| o.kind == NoteKind::Long)
                 .map(|o| o.offset)
                 .collect();
-            let mut ln_intervals: Vec<(ObjTime, ObjTime)> = Vec::new();
-            let mut iter = long_times.clone().into_iter();
-            while let Some(start) = iter.next() {
-                if let Some(end) = iter.next() {
-                    if end >= start {
-                        ln_intervals.push((start, end));
-                    }
-                } else {
-                    break;
-                }
-            }
 
             // Overlap single vs single at the same time
             let mut i = 0;

--- a/src/bms/parse/validity.rs
+++ b/src/bms/parse/validity.rs
@@ -108,6 +108,7 @@ pub enum ValidityInvalid {
 /// Output of validity checks.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[must_use]
 pub struct ValidityCheckOutput {
     /// Missing-related findings.
     pub missing: Vec<ValidityMissing>,

--- a/src/bms/parse/validity.rs
+++ b/src/bms/parse/validity.rs
@@ -106,7 +106,7 @@ pub enum ValidityInvalid {
 }
 
 /// Output of validity checks.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidityCheckOutput {
     /// Missing-related findings.

--- a/src/bms/parse/validity.rs
+++ b/src/bms/parse/validity.rs
@@ -21,19 +21,19 @@ use super::model::{Bms, obj::Obj};
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Error)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ValidityMissing {
-    /// A note references an ObjId without a corresponding WAV definition.
+    /// A note references an [`ObjId`] without a corresponding `#WAV` definition.
     #[error("Missing WAV definition for note object id: {0:?}")]
     WavForNote(ObjId),
-    /// A BGM references an ObjId without a corresponding WAV definition.
+    /// A BGM references an [`ObjId`] without a corresponding `#WAV` definition.
     #[error("Missing WAV definition for BGM object id: {0:?}")]
     WavForBgm(ObjId),
-    /// A BGA change references an ObjId without a corresponding BMP/EXBMP definition.
+    /// A BGA change references an [`ObjId`] without a corresponding `#BMP`/`#EXBMP` definition.
     #[error("Missing BMP definition for BGA object id: {0:?}")]
     BmpForBga(ObjId),
-    /// A BPM change references an ObjId without a corresponding #BPMxx definition.
+    /// A BPM change references an [`ObjId`] without a corresponding `#BPMxx` definition.
     #[error("Missing BPM change definition for object id: {0:?}")]
     BpmChangeDef(ObjId),
-    /// A STOP event references an ObjId without a corresponding #STOPxx definition.
+    /// A STOP event references an [`ObjId`] without a corresponding `#STOPxx` definition.
     #[error("Missing STOP definition for object id: {0:?}")]
     StopDef(ObjId),
 }

--- a/src/bms/parse/validity.rs
+++ b/src/bms/parse/validity.rs
@@ -194,7 +194,7 @@ impl Bms {
                     .push(obj);
             }
         }
-        for ((side, key), objs) in lane_to_notes.into_iter() {
+        for ((side, key), objs) in lane_to_notes {
             if objs.is_empty() {
                 continue;
             }

--- a/src/bmson.rs
+++ b/src/bmson.rs
@@ -150,7 +150,7 @@ pub fn default_percentage() -> FinF64 {
 }
 
 /// Default resolution pulses per quarter note in 4/4 measure, 240 pulses.
-pub fn default_resolution() -> u64 {
+pub const fn default_resolution() -> u64 {
     240
 }
 

--- a/src/bmson.rs
+++ b/src/bmson.rs
@@ -137,11 +137,13 @@ pub struct BmsonInfo {
 }
 
 /// Default mode hint, beatmania 7 keys.
+#[must_use]
 pub fn default_mode_hint() -> String {
     "beat-7k".into()
 }
 
 /// Default relative percentage, 100%.
+#[must_use]
 pub fn default_percentage() -> FinF64 {
     FinF64::new(100.0).unwrap_or_else(|| {
         // This should never happen as 100.0 is a valid FinF64 value
@@ -150,6 +152,7 @@ pub fn default_percentage() -> FinF64 {
 }
 
 /// Default resolution pulses per quarter note in 4/4 measure, 240 pulses.
+#[must_use]
 pub const fn default_resolution() -> u64 {
     240
 }

--- a/src/bmson.rs
+++ b/src/bmson.rs
@@ -209,9 +209,8 @@ where
 {
     let opt = Option::<u8>::deserialize(deserializer)?;
     Ok(match opt {
-        Some(0) => None,
+        Some(0) | None => None,
         Some(v) => NonZeroU8::new(v),
-        None => None,
     })
 }
 

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -57,14 +57,14 @@ pub struct BmsToBmsonOutput {
 impl Bms {
     /// Convert `Bms` to `Bmson`.
     pub fn to_bmson(self) -> BmsToBmsonOutput {
-        let mut warnings = Vec::new();
-        let converter = PulseConverter::new(&self);
-
         const EASY_WIDTH: f64 = 21.0;
         const VERY_EASY_WIDTH: f64 = EASY_WIDTH * 1.25;
         const NORMAL_WIDTH: f64 = 18.0;
         const HARD_WIDTH: f64 = 15.0;
         const VERY_HARD_WIDTH: f64 = 8.0;
+
+        let mut warnings = Vec::new();
+        let converter = PulseConverter::new(&self);
         let judge_rank = FinF64::new(match self.header.rank {
             Some(JudgeLevel::OtherInt(4)) => VERY_EASY_WIDTH / NORMAL_WIDTH, // VeryEasy implementation of beatoraja.
             Some(JudgeLevel::Easy) => EASY_WIDTH / NORMAL_WIDTH,

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -67,10 +67,9 @@ impl Bms {
         let judge_rank = FinF64::new(match self.header.rank {
             Some(JudgeLevel::OtherInt(4)) => VERY_EASY_WIDTH / NORMAL_WIDTH, // VeryEasy implementation of beatoraja.
             Some(JudgeLevel::Easy) => EASY_WIDTH / NORMAL_WIDTH,
-            Some(JudgeLevel::Normal) | None => 1.0,
+            Some(JudgeLevel::Normal) | Some(JudgeLevel::OtherInt(_)) | None => 1.0,
             Some(JudgeLevel::Hard) => HARD_WIDTH / NORMAL_WIDTH,
             Some(JudgeLevel::VeryHard) => VERY_HARD_WIDTH / NORMAL_WIDTH,
-            Some(JudgeLevel::OtherInt(_)) => 1.0,
         })
         .unwrap_or_else(|| {
             warnings.push(BmsToBmsonWarning::InvalidJudgeRank);

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -167,8 +167,7 @@ impl Bms {
             back_image: self
                 .header
                 .back_bmp
-                .as_ref()
-                .cloned()
+                .clone()
                 .map(|path| path.display().to_string()),
             eyecatch_image: self
                 .header

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -305,7 +305,7 @@ impl Bms {
                 target.push(BgaEvent {
                     y: converter.get_pulses_at(time),
                     id: BgaId(change.id.as_u32()),
-                })
+                });
             }
             bga
         };

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -46,6 +46,7 @@ pub enum BmsToBmsonWarning {
 
 /// Output of the conversion from `Bms` to `Bmson`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub struct BmsToBmsonOutput {
     /// The converted `Bmson` object.
     pub bmson: Bmson,

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -233,10 +233,9 @@ impl Bms {
                         let duration = self
                             .notes
                             .next_obj_by_key(note.side, note.key, note.offset)
-                            .map(|next_note| {
+                            .map_or(0, |next_note| {
                                 pulses.abs_diff(converter.get_pulses_at(next_note.offset))
-                            })
-                            .unwrap_or(0);
+                            });
                         sound_map.entry(note.obj).or_default().push(Note {
                             x: note_lane,
                             y: pulses,

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -68,7 +68,7 @@ impl Bms {
         let judge_rank = FinF64::new(match self.header.rank {
             Some(JudgeLevel::OtherInt(4)) => VERY_EASY_WIDTH / NORMAL_WIDTH, // VeryEasy implementation of beatoraja.
             Some(JudgeLevel::Easy) => EASY_WIDTH / NORMAL_WIDTH,
-            Some(JudgeLevel::Normal) | Some(JudgeLevel::OtherInt(_)) | None => 1.0,
+            Some(JudgeLevel::Normal | JudgeLevel::OtherInt(_)) | None => 1.0,
             Some(JudgeLevel::Hard) => HARD_WIDTH / NORMAL_WIDTH,
             Some(JudgeLevel::VeryHard) => VERY_HARD_WIDTH / NORMAL_WIDTH,
         })

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -137,7 +137,7 @@ impl Bms {
                     (false, false) => "beat-5k".into(),
                 }
             },
-            chart_name: "".into(),
+            chart_name: String::new(),
             level: self.header.play_level.unwrap_or_default() as u32,
             init_bpm: {
                 let bpm_value = if let Some(bpm) = self.arrangers.bpm.as_ref() {

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -45,7 +45,7 @@ pub enum BmsToBmsonWarning {
 }
 
 /// Output of the conversion from `Bms` to `Bmson`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BmsToBmsonOutput {
     /// The converted `Bmson` object.
     pub bmson: Bmson,

--- a/src/bmson/bmson_to_bms.rs
+++ b/src/bmson/bmson_to_bms.rs
@@ -56,7 +56,7 @@ impl Iterator for ObjIdIssuer {
 }
 
 /// Output of the conversion from `Bmson` to `Bms`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BmsonToBmsOutput {
     /// The converted `Bms` object.
     pub bms: Bms,

--- a/src/bmson/bmson_to_bms.rs
+++ b/src/bmson/bmson_to_bms.rs
@@ -320,7 +320,7 @@ impl Bms {
     }
 }
 
-/// Convert pulse number to ObjTime
+/// Converts a pulse number to [`ObjTime`]
 fn convert_pulse_to_obj_time(pulse: PulseNumber, resolution: u64) -> ObjTime {
     // Simple conversion: assume 4/4 time signature and convert pulses to track/time
     let pulses_per_measure = resolution * 4; // 4 quarter notes per measure
@@ -334,7 +334,7 @@ fn convert_pulse_to_obj_time(pulse: PulseNumber, resolution: u64) -> ObjTime {
     ObjTime::new(track, numerator, denominator)
 }
 
-/// Convert lane number to Key and PlayerSide
+/// Converts a lane number to [`Key`] and [`PlayerSide`]
 fn convert_lane_to_key_side(lane: Option<NonZeroU8>) -> (Key, PlayerSide) {
     let lane_value = lane.map_or(0, |l| l.get());
 
@@ -361,7 +361,7 @@ fn convert_lane_to_key_side(lane: Option<NonZeroU8>) -> (Key, PlayerSide) {
     (key, side)
 }
 
-/// Create ObjId from u16
+/// Creates an [`ObjId`] from `u16`
 fn create_obj_id_from_u16(value: u16) -> Result<ObjId, ()> {
     let mut chars = ['0'; 2];
     let first = (value / 62) as u8;

--- a/src/bmson/bmson_to_bms.rs
+++ b/src/bmson/bmson_to_bms.rs
@@ -57,6 +57,7 @@ impl Iterator for ObjIdIssuer {
 
 /// Output of the conversion from `Bmson` to `Bms`.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
 pub struct BmsonToBmsOutput {
     /// The converted `Bms` object.
     pub bms: Bms,

--- a/src/bmson/bmson_to_bms.rs
+++ b/src/bmson/bmson_to_bms.rs
@@ -336,7 +336,7 @@ fn convert_pulse_to_obj_time(pulse: PulseNumber, resolution: u64) -> ObjTime {
 
 /// Convert lane number to Key and PlayerSide
 fn convert_lane_to_key_side(lane: Option<NonZeroU8>) -> (Key, PlayerSide) {
-    let lane_value = lane.map(|l| l.get()).unwrap_or(0);
+    let lane_value = lane.map_or(0, |l| l.get());
 
     // Handle player sides
     let (adjusted_lane, side) = if lane_value > 8 {

--- a/src/bmson/bmson_to_bms.rs
+++ b/src/bmson/bmson_to_bms.rs
@@ -71,7 +71,7 @@ pub struct BmsonToBmsOutput {
 impl Bms {
     /// Convert `Bmson` to `Bms`.
     pub fn from_bmson(value: Bmson) -> BmsonToBmsOutput {
-        let mut bms = Bms::default();
+        let mut bms = Self::default();
         let mut warnings = Vec::new();
         let mut wav_obj_id_issuer = ObjIdIssuer::new();
         let mut bga_header_obj_id_issuer = ObjIdIssuer::new();

--- a/src/bmson/fin_f64.rs
+++ b/src/bmson/fin_f64.rs
@@ -54,12 +54,14 @@ impl AsRef<f64> for FinF64 {
 impl FinF64 {
     /// Creates a new `FinF64` from `f64` if `float` is finite, otherwise returns `None`.
     #[inline]
+    #[must_use]
     pub fn new(float: f64) -> Option<Self> {
         Self::try_from(float).ok()
     }
 
     /// Gets the internal value.
     #[inline]
+    #[must_use]
     pub const fn as_f64(self) -> f64 {
         self.0
     }

--- a/src/bmson/fin_f64.rs
+++ b/src/bmson/fin_f64.rs
@@ -60,7 +60,7 @@ impl FinF64 {
 
     /// Gets the internal value.
     #[inline]
-    pub fn as_f64(self) -> f64 {
+    pub const fn as_f64(self) -> f64 {
         self.0
     }
 }

--- a/src/bmson/pulse.rs
+++ b/src/bmson/pulse.rs
@@ -42,7 +42,7 @@ impl PulseConverter {
                 .arrangers
                 .section_len_changes
                 .get(&Track(current_track))
-                .map_or(Decimal::from(1u64), |section| section.length.clone())
+                .map_or_else(|| Decimal::from(1u64), |section| section.length.clone())
                 .try_into()
                 .unwrap_or(1.0);
             current_pulses = current_pulses.saturating_add((section_len * 4.0) as u64 * resolution);

--- a/src/bmson/pulse.rs
+++ b/src/bmson/pulse.rs
@@ -15,6 +15,7 @@ pub struct PulseNumber(pub u64);
 
 impl PulseNumber {
     /// Calculates an absolute difference of two pulses.
+    #[must_use]
     pub const fn abs_diff(self, other: Self) -> u64 {
         self.0.abs_diff(other.0)
     }
@@ -29,6 +30,7 @@ pub struct PulseConverter {
 
 impl PulseConverter {
     /// Creates a new converter from [`Notes`].
+    #[must_use]
     pub fn new(bms: &crate::bms::parse::model::Bms) -> Self {
         let resolution: u64 = bms.resolution_for_pulses();
         let last_track = bms.last_obj_time().map_or(0, |time| time.track.0);
@@ -59,6 +61,7 @@ impl PulseConverter {
     }
 
     /// Gets pulses on the start of [`Track`].
+    #[must_use]
     pub fn get_pulses_on(&self, track: Track) -> PulseNumber {
         PulseNumber(
             self.pulses_at_track_start
@@ -74,6 +77,7 @@ impl PulseConverter {
     }
 
     /// Gets pulses at the [`ObjTime`].
+    #[must_use]
     pub fn get_pulses_at(&self, time: ObjTime) -> PulseNumber {
         let PulseNumber(track_base) = self.get_pulses_on(time.track);
         PulseNumber(track_base + (4 * self.resolution * time.numerator / time.denominator))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! #[cfg(not(feature = "rand"))]
 //! let AstParseOutput { token_refs } = root.parse(RngMock([BigUint::from(1u64)]));
 //! let ParseOutput { bms, parse_warnings }:  ParseOutput<bms_rs::bms::command::channel::mapper::KeyLayoutBeat> = Bms::from_token_stream(
-//!     &token_refs, AlwaysWarnAndUseNewer
+//!     token_refs, AlwaysWarnAndUseNewer
 //! );
 //! // According to [BMS command memo#BEHAVIOR IN GENERAL IMPLEMENTATION](https://hitkey.bms.ms/cmds.htm#BEHAVIOR-IN-GENERAL-IMPLEMENTATION), the newer values are used for the duplicated objects.
 //! assert_eq!(parse_warnings, vec![]);


### PR DESCRIPTION
- **Make const fn as possible**
- **Replace equatable if let**
- **Reduce function call on or branch**
- **Prefer to use Self**
- **Derive Eq**
- **Remove unused**
- **Improve check_validity complexity**
- **Organize match arms**
- **Take reference to reduce moves**
- **Reduce clones**
- **Append must_use**
- **Prefer map_or**
- **Unnest patterns**
- **Extract constant and separate digits**
- **Inline format args**
- **Fix typo**
- **Fix TokenRefStream's IntoIterator impl**
- **Move adding items before statements**
- **Add semicolons**
- **Elide lifetime**
- **Avoid to use default for PhantomData**
- **Fix markdown in doc comments**
- **Clone Option directly**
- **Extract min and max frequency**
- **Append must_use**
- **Invert if to avoid not operator**
- **Use find_map**
- **Prefer assert than if and panic**
- **Use assert**
- **Use find_map**
- **Remove needless semicolon**
- **Use values_mut**
- **Use string constructor**
- **Remove needless into_iter**
- **Fix Panics section notation**
