### PR TITLE
refactor!: decouple key layout from parse pipeline, move converter to chart layer

### DIFF
--- a/src/bms.rs
+++ b/src/bms.rs
@@ -15,7 +15,7 @@
 //! - Do not support commands having ambiguous semantics.
 //! - Do not support syntax came from typo (such as `#RONDOM` or `#END IF`).
 
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 pub mod command;
 
@@ -39,7 +39,7 @@ use self::{
     model::Bms,
     parse::{
         ParseErrorWithRange, ParseWarningWithRange,
-        check_playing::{PlayingCheckOutput, PlayingError, PlayingWarning},
+        check_playing::{PlayingError, PlayingWarning},
         token_processor::{
             DefaultTokenRelaxer, NoopTokenModifier, SequentialTokenModifier, TokenModifier,
             TokenProcessor, full_preset,
@@ -69,69 +69,50 @@ pub enum BmsWarning {
 
 /// A configuration builder for [`parse_bms`]. Its methods can be chained to set parameters you want.
 #[must_use]
-pub struct ParseConfig<T, P, R, M> {
-    key_mapper: PhantomData<fn() -> T>,
+pub struct ParseConfig<P, R, M> {
     prompter: P,
     rng: R,
     token_modifier: M,
 }
 
-/// Creates the default configuration builder with the basic key layout [`KeyLayoutBeat`], the prompter [`AlwaysWarnAndUseNewer`] and the standard RNG [`rand::rngs::StdRng`].
+/// Creates the default configuration builder with the prompter [`AlwaysWarnAndUseNewer`] and the standard RNG [`rand::rngs::StdRng`].
 #[cfg(feature = "rand")]
-pub fn default_config() -> ParseConfig<
-    KeyLayoutBeat,
-    AlwaysWarnAndUseNewer,
-    RandRng<rand::rngs::StdRng>,
-    DefaultTokenRelaxer,
-> {
+pub fn default_config()
+-> ParseConfig<AlwaysWarnAndUseNewer, RandRng<rand::rngs::StdRng>, DefaultTokenRelaxer> {
     ParseConfig {
-        key_mapper: PhantomData,
         prompter: AlwaysWarnAndUseNewer,
         rng: RandRng(rand::make_rng()),
         token_modifier: DefaultTokenRelaxer,
     }
 }
 
-/// Creates the default configuration builder with the basic key layout [`KeyLayoutBeat`], the prompter [`AlwaysWarnAndUseNewer`] and the Java-compatible RNG.
+/// Creates the default configuration builder with the prompter [`AlwaysWarnAndUseNewer`] and the Java-compatible RNG.
 /// This version is available when the `rand` feature is not enabled.
 #[cfg(not(feature = "rand"))]
-pub fn default_config()
--> ParseConfig<KeyLayoutBeat, AlwaysWarnAndUseNewer, rng::JavaRandom, DefaultTokenRelaxer> {
+pub fn default_config() -> ParseConfig<AlwaysWarnAndUseNewer, rng::JavaRandom, DefaultTokenRelaxer>
+{
     ParseConfig {
-        key_mapper: PhantomData,
         prompter: AlwaysWarnAndUseNewer,
         rng: rng::JavaRandom::default(),
         token_modifier: DefaultTokenRelaxer,
     }
 }
 
-/// Creates the default configuration builder with the basic key layout [`KeyLayoutBeat`], the prompter [`AlwaysWarnAndUseNewer`] and your RNG.
-pub fn default_config_with_rng<R>(
+/// Creates the default configuration builder with the prompter [`AlwaysWarnAndUseNewer`] and your RNG.
+pub const fn default_config_with_rng<R>(
     rng: R,
-) -> ParseConfig<KeyLayoutBeat, AlwaysWarnAndUseNewer, R, DefaultTokenRelaxer> {
+) -> ParseConfig<AlwaysWarnAndUseNewer, R, DefaultTokenRelaxer> {
     ParseConfig {
-        key_mapper: PhantomData,
         prompter: AlwaysWarnAndUseNewer,
         rng,
         token_modifier: DefaultTokenRelaxer,
     }
 }
 
-impl<T, P, R, M> ParseConfig<T, P, R, M> {
-    /// Sets the key mapper to the `T2` one.
-    pub fn key_mapper<T2: KeyLayoutMapper>(self) -> ParseConfig<T2, P, R, M> {
-        ParseConfig {
-            key_mapper: PhantomData,
-            prompter: self.prompter,
-            rng: self.rng,
-            token_modifier: self.token_modifier,
-        }
-    }
-
+impl<P, R, M> ParseConfig<P, R, M> {
     /// Sets the prompter to `prompter`.
-    pub fn prompter<P2: Prompter>(self, prompter: P2) -> ParseConfig<T, P2, R, M> {
+    pub fn prompter<P2: Prompter>(self, prompter: P2) -> ParseConfig<P2, R, M> {
         ParseConfig {
-            key_mapper: PhantomData,
             prompter,
             rng: self.rng,
             token_modifier: self.token_modifier,
@@ -139,9 +120,8 @@ impl<T, P, R, M> ParseConfig<T, P, R, M> {
     }
 
     /// Sets the RNG to `rng`.
-    pub fn rng<R2: Rng>(self, rng: R2) -> ParseConfig<T, P, R2, M> {
+    pub fn rng<R2: Rng>(self, rng: R2) -> ParseConfig<P, R2, M> {
         ParseConfig {
-            key_mapper: PhantomData,
             prompter: self.prompter,
             rng,
             token_modifier: self.token_modifier,
@@ -155,12 +135,11 @@ impl<T, P, R, M> ParseConfig<T, P, R, M> {
     pub fn append_token_modifier<M2: TokenModifier>(
         self,
         token_modifier: M2,
-    ) -> ParseConfig<T, P, R, SequentialTokenModifier<M, M2>>
+    ) -> ParseConfig<P, R, SequentialTokenModifier<M, M2>>
     where
         M: TokenModifier,
     {
         ParseConfig {
-            key_mapper: PhantomData,
             prompter: self.prompter,
             rng: self.rng,
             token_modifier: self.token_modifier.then(token_modifier),
@@ -171,9 +150,8 @@ impl<T, P, R, M> ParseConfig<T, P, R, M> {
     pub fn override_token_modifier<M2: TokenModifier>(
         self,
         token_modifier: M2,
-    ) -> ParseConfig<T, P, R, M2> {
+    ) -> ParseConfig<P, R, M2> {
         ParseConfig {
-            key_mapper: PhantomData,
             prompter: self.prompter,
             rng: self.rng,
             token_modifier,
@@ -185,12 +163,11 @@ impl<T, P, R, M> ParseConfig<T, P, R, M> {
     /// Accepts a closure `f` that takes the current modifier `M` and returns a new
     /// modifier `M2`. This is useful for wrapping, decorating, or transforming the
     /// modifier while keeping static dispatch.
-    pub fn map_token_modifier<F, M2>(self, f: F) -> ParseConfig<T, P, R, M2>
+    pub fn map_token_modifier<F, M2>(self, f: F) -> ParseConfig<P, R, M2>
     where
         F: FnOnce(M) -> M2,
     {
         ParseConfig {
-            key_mapper: PhantomData,
             prompter: self.prompter,
             rng: self.rng,
             token_modifier: f(self.token_modifier),
@@ -198,33 +175,30 @@ impl<T, P, R, M> ParseConfig<T, P, R, M> {
     }
 
     /// Clean all token modifiers by switching to a no-op modifier.
-    pub fn clean_token_modifier(self) -> ParseConfig<T, P, R, NoopTokenModifier> {
+    pub fn clean_token_modifier(self) -> ParseConfig<P, R, NoopTokenModifier> {
         self.override_token_modifier(NoopTokenModifier)
     }
 
     pub(crate) fn build(self) -> (impl TokenProcessor<Output = Bms>, P)
     where
-        T: KeyLayoutMapper,
         P: Prompter,
         R: Rng,
     {
-        struct AggregateTokenProcessor<T, R> {
-            key_mapper: PhantomData<fn() -> T>,
+        struct AggregateTokenProcessor<R> {
             rng: Rc<RefCell<R>>,
         }
-        impl<T: KeyLayoutMapper, R: Rng> TokenProcessor for AggregateTokenProcessor<T, R> {
+        impl<R: Rng> TokenProcessor for AggregateTokenProcessor<R> {
             type Output = Bms;
 
             fn process<P: Prompter>(
                 &self,
                 ctx: &mut parse::token_processor::ProcessContext<'_, '_, P>,
             ) -> Result<Self::Output, ParseErrorWithRange> {
-                full_preset::<T, R>(Rc::clone(&self.rng)).process(ctx)
+                full_preset::<R>(Rc::clone(&self.rng)).process(ctx)
             }
         }
         (
-            AggregateTokenProcessor::<T, R> {
-                key_mapper: PhantomData,
+            AggregateTokenProcessor {
                 rng: Rc::new(RefCell::new(self.rng)),
             },
             self.prompter,
@@ -233,42 +207,26 @@ impl<T, P, R, M> ParseConfig<T, P, R, M> {
 }
 
 /// Parse a BMS file from source text with the specified command preset.
-pub fn parse_bms<T: KeyLayoutMapper, P: Prompter, R: Rng, M: TokenModifier>(
+pub fn parse_bms<P: Prompter, R: Rng, M: TokenModifier>(
     source: &str,
-    config: ParseConfig<T, P, R, M>,
+    config: ParseConfig<P, R, M>,
 ) -> BmsOutput {
-    // Parse tokens using default channel parser
     let LexOutput {
         mut tokens,
         lex_warnings,
     } = lex::TokenStream::parse_lex(source);
 
-    // Convert lex warnings to BmsWarning
     let mut warnings: Vec<BmsWarning> = lex_warnings.into_iter().map(BmsWarning::Lex).collect();
 
     config.token_modifier.modify(&mut tokens);
-    let parse_output = Bms::from_token_stream::<'_, T, _, _, _>(&tokens, config);
+    let parse_output = Bms::from_token_stream::<'_, _, _, _>(&tokens, config);
     let bms_result = parse_output.bms;
-    // Convert parse warnings to BmsWarning
     warnings.extend(
         parse_output
             .parse_warnings
             .into_iter()
             .map(BmsWarning::Parse),
     );
-
-    if let Ok(ref bms) = bms_result {
-        let PlayingCheckOutput {
-            playing_warnings,
-            playing_errors,
-        } = bms.check_playing::<T>();
-
-        // Convert playing warnings to BmsWarning
-        warnings.extend(playing_warnings.into_iter().map(BmsWarning::PlayingWarning));
-
-        // Convert playing errors to BmsWarning
-        warnings.extend(playing_errors.into_iter().map(BmsWarning::PlayingError));
-    }
 
     BmsOutput {
         bms: bms_result,

--- a/src/bms/command/channel.rs
+++ b/src/bms/command/channel.rs
@@ -11,7 +11,6 @@ use thiserror::Error;
 
 use self::mapper::KeyLayoutMapper;
 
-pub mod converter;
 pub mod mapper;
 
 /// The channel, or lane, where the note will be on.

--- a/src/bms/model/notes.rs
+++ b/src/bms/model/notes.rs
@@ -41,7 +41,7 @@ pub struct Notes {
     arena: WavObjArena,
     /// Note objects index for each wav sound of [`ObjId`].
     idx_by_wav_id: HashMap<ObjId, Vec<WavObjArenaIndex>>,
-    /// Note objects index for each channel from the mapping `T`.
+    /// Note objects index for each channel.
     idx_by_channel: HashMap<NoteChannelId, Vec<WavObjArenaIndex>>,
     /// Note objects index sorted by its time.
     idx_by_time: BTreeMap<ObjTime, Vec<WavObjArenaIndex>>,
@@ -130,88 +130,7 @@ impl Notes {
         self.arena.0.iter()
     }
 
-    /// Returns all the playable notes in the score.
-    ///
-    /// # Note
-    /// This iterator may include dangling objects (objects with null `wav_id`) that reference
-    /// non-existent WAV files. These dangling objects represent invalid or unassigned notes
-    /// and do not affect musical playback.
-    /// They may originate from parsing issues in the original BMS file or from user modifications
-    /// to the Notes object.
-    ///
-    /// To filter out dangling objects, use:
-    /// ```rust
-    /// # use bms_rs::bms::prelude::*;
-    /// # let notes = Notes::default();
-    /// notes.playables::<KeyLayoutBeat>().filter(|obj| !obj.wav_id.is_null())
-    /// # ;
-    /// ```
-    pub fn playables<T>(&self) -> impl Iterator<Item = &WavObj>
-    where
-        T: KeyLayoutMapper,
-    {
-        self.arena.0.iter().sorted().filter(|obj| {
-            obj.channel_id
-                .try_into_map::<T>()
-                .is_some_and(|map| map.kind().is_playable())
-        })
-    }
-
-    /// Returns all the displayable notes in the score.
-    ///
-    /// # Note
-    /// This iterator may include dangling objects (objects with null `wav_id`) that reference
-    /// non-existent WAV files. These dangling objects represent invalid or unassigned notes
-    /// and do not affect musical playback.
-    /// They may originate from parsing issues in the original BMS file or from user modifications
-    /// to the Notes object.
-    ///
-    /// To filter out dangling objects, use:
-    /// ```rust
-    /// # use bms_rs::bms::prelude::*;
-    /// # let notes = Notes::default();
-    /// notes.displayables::<KeyLayoutBeat>().filter(|obj| !obj.wav_id.is_null())
-    /// # ;
-    /// ```
-    pub fn displayables<T>(&self) -> impl Iterator<Item = &WavObj>
-    where
-        T: KeyLayoutMapper,
-    {
-        self.arena.0.iter().sorted().filter(|obj| {
-            obj.channel_id
-                .try_into_map::<T>()
-                .is_some_and(|map| map.kind().is_displayable())
-        })
-    }
-
-    /// Returns all the bgms in the score.
-    ///
-    /// # Note
-    /// This iterator may include dangling objects (objects with null `wav_id`) that reference
-    /// non-existent WAV files. These dangling objects represent invalid or unassigned notes
-    /// and do not affect musical playback.
-    /// They may originate from parsing issues in the original BMS file or from user modifications
-    /// to the Notes object.
-    ///
-    /// To filter out dangling objects, use:
-    /// ```rust
-    /// # use bms_rs::bms::prelude::*;
-    /// # let notes = Notes::default();
-    /// notes.bgms::<KeyLayoutBeat>().filter(|obj| !obj.wav_id.is_null())
-    /// # ;
-    /// ```
-    pub fn bgms<T>(&self) -> impl Iterator<Item = &WavObj>
-    where
-        T: KeyLayoutMapper,
-    {
-        self.arena.0.iter().sorted().filter(|obj| {
-            obj.channel_id
-                .try_into_map::<T>()
-                .is_none_or(|map| !map.kind().is_displayable())
-        })
-    }
-
-    /// Retrieves notes on the specified channel id by the key mapping `T`.
+    /// Retrieves notes on the specified channel id.
     ///
     /// # Note
     /// This iterator may include dangling objects (objects with null `wav_id`) that reference
@@ -225,15 +144,12 @@ impl Notes {
     /// # use bms_rs::bms::prelude::*;
     /// # let notes = Notes::default();
     /// let channel_id = NoteChannelId::try_from(['0', '1']).unwrap();
-    /// notes.notes_on::<KeyLayoutBeat>(channel_id).filter(|(_, obj)| !obj.wav_id.is_null());
+    /// notes.notes_on(channel_id).filter(|(_, obj)| !obj.wav_id.is_null());
     /// ```
-    pub fn notes_on<T>(
+    pub fn notes_on(
         &self,
         channel_id: NoteChannelId,
-    ) -> impl Iterator<Item = (WavObjArenaIndex, &WavObj)>
-    where
-        T: KeyLayoutMapper,
-    {
+    ) -> impl Iterator<Item = (WavObjArenaIndex, &WavObj)> {
         self.idx_by_channel
             .get(&channel_id)
             .into_iter()
@@ -291,42 +207,6 @@ impl Notes {
     pub fn last_obj_time(&self) -> Option<ObjTime> {
         let (&time, _) = self.idx_by_time.last_key_value()?;
         Some(time)
-    }
-
-    /// Gets the time of last playable object.
-    #[must_use]
-    pub fn last_playable_time<T>(&self) -> Option<ObjTime>
-    where
-        T: KeyLayoutMapper,
-    {
-        self.notes_in(..)
-            .map(|(_, obj)| obj)
-            .rev()
-            .find(|obj| {
-                obj.channel_id
-                    .try_into_map::<T>()
-                    .is_some_and(|map| map.kind().is_displayable())
-            })
-            .map(|obj| obj.offset)
-    }
-
-    /// Gets the time of last BGM object.
-    ///
-    /// You can't use this to find the length of music. Because this doesn't consider that the length of sound. And visible notes may ring after all BGMs.
-    #[must_use]
-    pub fn last_bgm_time<T>(&self) -> Option<ObjTime>
-    where
-        T: KeyLayoutMapper,
-    {
-        self.notes_in(..)
-            .map(|(_, obj)| obj)
-            .rev()
-            .find(|obj| {
-                obj.channel_id
-                    .try_into_map::<T>()
-                    .is_none_or(|map| !map.kind().is_displayable())
-            })
-            .map(|obj| obj.offset)
     }
 }
 
@@ -388,10 +268,7 @@ impl Notes {
     }
 
     /// Removes notes belonging to the wav id.
-    pub fn remove_note<T>(&mut self, wav_id: ObjId) -> Vec<WavObj>
-    where
-        T: KeyLayoutMapper,
-    {
+    pub fn remove_note(&mut self, wav_id: ObjId) -> Vec<WavObj> {
         let Some(indexes) = self.idx_by_wav_id.remove(&wav_id) else {
             return vec![];
         };
@@ -415,10 +292,7 @@ impl Notes {
     }
 
     /// Removes the latest note using the wav of `wav_id`.
-    pub fn pop_latest_of<T>(&mut self, wav_id: ObjId) -> Option<WavObj>
-    where
-        T: KeyLayoutMapper,
-    {
+    pub fn pop_latest_of(&mut self, wav_id: ObjId) -> Option<WavObj> {
         let &WavObjArenaIndex(to_pop) = self.idx_by_wav_id.get(&wav_id)?.last()?;
         let removing = std::mem::replace(self.arena.0.get_mut(to_pop)?, WavObj::dangling());
         self.remove_index(to_pop, &removing);
@@ -426,22 +300,17 @@ impl Notes {
     }
 
     /// Adds the BGM (auto-played) note of `wav_id` at `time`.
-    pub fn push_bgm<T>(&mut self, time: ObjTime, wav_id: ObjId)
-    where
-        T: KeyLayoutMapper,
-    {
+    pub fn push_bgm(&mut self, time: ObjTime, wav_id: ObjId) {
         self.push_note(WavObj {
             offset: time,
             channel_id: NoteChannelId::bgm(),
             wav_id,
+            ln_end_for: None,
         });
     }
 
     /// Retains note objects with the condition `cond`. It keeps only the [`WavObj`]s which `cond` returned `true`.
-    pub fn retain_notes<T, F: FnMut(&WavObj) -> bool>(&mut self, mut cond: F)
-    where
-        T: KeyLayoutMapper,
-    {
+    pub fn retain_notes<F: FnMut(&WavObj) -> bool>(&mut self, mut cond: F) {
         let removing_indexes: Vec<_> = self
             .arena
             .0
@@ -540,6 +409,7 @@ mod tests {
             offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
             channel_id: NoteChannelId::bgm(),
             wav_id: ObjId::try_from("01", false).unwrap(),
+            ln_end_for: None,
         };
 
         assert!(notes.pop_note().is_none());
@@ -558,6 +428,7 @@ mod tests {
             offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
             channel_id: NoteChannelId::bgm(),
             wav_id: ObjId::try_from("01", false).unwrap(),
+            ln_end_for: None,
         };
 
         assert!(notes.pop_note().is_none());
@@ -576,6 +447,7 @@ mod tests {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: ObjId::try_from("01", false).unwrap(),
+                ln_end_for: None,
             })
         );
     }
@@ -587,6 +459,7 @@ mod tests {
             offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
             channel_id: NoteChannelId::bgm(),
             wav_id: ObjId::try_from("01", false).unwrap(),
+            ln_end_for: None,
         };
 
         assert!(notes.pop_note().is_none());
@@ -604,6 +477,7 @@ mod tests {
                 offset: ObjTime::new(1, 1, 4,).expect("4 should be a valid denominator"),
                 channel_id: NoteChannelId::bgm(),
                 wav_id: ObjId::try_from("01", false).unwrap(),
+                ln_end_for: None,
             })
         );
     }

--- a/src/bms/model/obj.rs
+++ b/src/bms/model/obj.rs
@@ -20,6 +20,9 @@ pub struct WavObj {
     pub channel_id: NoteChannelId,
     /// The `#WAVxx` id to be rung on play.
     pub wav_id: ObjId,
+    /// For LN begin notes: the end note's offset time. `None` for non-LN or LN end notes.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub ln_end_for: Option<ObjTime>,
 }
 
 impl PartialOrd for WavObj {
@@ -33,6 +36,7 @@ impl Ord for WavObj {
         self.offset
             .cmp(&other.offset)
             .then(self.wav_id.cmp(&other.wav_id))
+            .then(self.ln_end_for.cmp(&other.ln_end_for))
     }
 }
 
@@ -42,6 +46,7 @@ impl WavObj {
             offset: ObjTime::start_of(1.into()),
             channel_id: NoteChannelId::bgm(),
             wav_id: ObjId::null(),
+            ln_end_for: None,
         }
     }
 }

--- a/src/bms/parse.rs
+++ b/src/bms/parse.rs
@@ -24,7 +24,7 @@ use crate::bms::{
     ParseConfig,
     command::{
         ObjId,
-        channel::{Channel, mapper::KeyLayoutMapper},
+        channel::Channel,
         mixin::SourceRangeMixin,
         time::{ObjTime, Track},
     },
@@ -139,9 +139,9 @@ pub struct ParseOutput {
 
 impl Bms {
     /// Parses a token stream into [`Bms`] without AST.
-    pub fn from_token_stream<'a, T: KeyLayoutMapper, P: Prompter, R: Rng, M: TokenModifier>(
+    pub fn from_token_stream<'a, P: Prompter, R: Rng, M: TokenModifier>(
         token_iter: impl IntoIterator<Item = &'a TokenWithRange<'a>>,
-        config: ParseConfig<T, P, R, M>,
+        config: ParseConfig<P, R, M>,
     ) -> ParseOutput {
         let tokens: Vec<_> = token_iter.into_iter().collect();
         let mut tokens_slice = tokens.as_slice();

--- a/src/bms/parse/check_playing.rs
+++ b/src/bms/parse/check_playing.rs
@@ -3,9 +3,6 @@
 use thiserror::Error;
 
 use crate::bms::command::ObjId;
-use crate::bms::command::channel::mapper::KeyLayoutMapper;
-
-use crate::bms::model::Bms;
 
 #[cfg(feature = "diagnostics")]
 use crate::diagnostics::{SimpleSource, ToAriadne, build_report};
@@ -146,48 +143,4 @@ pub struct PlayingCheckOutput {
     pub playing_warnings: Vec<PlayingWarning>,
     /// List of [`PlayingError`]s.
     pub playing_errors: Vec<PlayingError>,
-}
-
-impl Bms {
-    /// Check for playing warnings and errors based on the parsed BMS data.
-    pub fn check_playing<T: KeyLayoutMapper>(&self) -> PlayingCheckOutput {
-        let mut playing_warnings = Vec::new();
-        let mut playing_errors = Vec::new();
-
-        // Check for TotalUndefined warning
-        if self.judge.total.is_none() {
-            playing_warnings.push(PlayingWarning::TotalUndefined);
-        }
-
-        // Check for BPM-related conditions
-        if self.bpm.bpm.is_none() {
-            if self.bpm.bpm_changes.is_empty() {
-                playing_errors.push(PlayingError::BpmUndefined);
-            } else {
-                playing_warnings.push(PlayingWarning::StartBpmUndefined);
-            }
-        }
-
-        // Check for notes
-        if self.wav.notes.is_empty() {
-            playing_errors.push(PlayingError::NoNotes);
-        } else {
-            // Check for displayable notes (Visible, Long, Landmine)
-            let has_displayable = self.wav.notes.displayables::<T>().next().is_some();
-            if !has_displayable {
-                playing_warnings.push(PlayingWarning::NoDisplayableNotes);
-            }
-
-            // Check for playable notes (all except Invisible)
-            let has_playable = self.wav.notes.playables::<T>().next().is_some();
-            if !has_playable {
-                playing_warnings.push(PlayingWarning::NoPlayableNotes);
-            }
-        }
-
-        PlayingCheckOutput {
-            playing_warnings,
-            playing_errors,
-        }
-    }
 }

--- a/src/bms/parse/token_processor.rs
+++ b/src/bms/parse/token_processor.rs
@@ -230,9 +230,7 @@ where
 }
 
 /// Returns all of processors this crate provided.
-pub fn full_preset<T: KeyLayoutMapper, R: Rng>(
-    rng: Rc<RefCell<R>>,
-) -> impl TokenProcessor<Output = Bms> {
+pub fn full_preset<R: Rng>(rng: Rc<RefCell<R>>) -> impl TokenProcessor<Output = Bms> {
     let case_sensitive_obj_id = Rc::new(RefCell::new(false));
     let sub_processor = repr::RepresentationProcessor::new(&case_sensitive_obj_id)
         .then(bmp::BmpProcessor::new(&case_sensitive_obj_id))
@@ -253,7 +251,7 @@ pub fn full_preset<T: KeyLayoutMapper, R: Rng>(
         .then(text::TextProcessor::new(&case_sensitive_obj_id))
         .then(video::VideoProcessor::new(&case_sensitive_obj_id))
         .then(volume::VolumeProcessor)
-        .then(wav::WavProcessor::<T>::new(&case_sensitive_obj_id));
+        .then(wav::WavProcessor::new(&case_sensitive_obj_id));
 
     let bms_mapper = sub_processor.map(
         |(

--- a/src/bms/parse/token_processor/wav.rs
+++ b/src/bms/parse/token_processor/wav.rs
@@ -17,7 +17,7 @@
 //! - `#xxx[D1-DZ]:` - Player 1 landmine channel with damage amount.
 //! - `#xxx[E1-EZ]:` - Player 2 landmine channel with damage amount.
 
-use std::{cell::RefCell, marker::PhantomData, path::Path, rc::Rc};
+use std::{cell::RefCell, path::Path, rc::Rc};
 
 use super::{
     super::prompt::{DefDuplication, Prompter},
@@ -35,21 +35,19 @@ use crate::{
 
 /// It processes `#WAVxx` and `#LNOBJ` definitions and objects on `Bgm` and `Note` channels.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WavProcessor<T> {
+pub struct WavProcessor {
     case_sensitive_obj_id: Rc<RefCell<bool>>,
-    _phantom: PhantomData<fn() -> T>,
 }
 
-impl<T: KeyLayoutMapper> WavProcessor<T> {
+impl WavProcessor {
     pub fn new(case_sensitive_obj_id: &Rc<RefCell<bool>>) -> Self {
         Self {
             case_sensitive_obj_id: Rc::clone(case_sensitive_obj_id),
-            _phantom: PhantomData,
         }
     }
 }
 
-impl<T: KeyLayoutMapper> TokenProcessor for WavProcessor<T> {
+impl TokenProcessor for WavProcessor {
     type Output = WavObjects;
 
     fn process<P: Prompter>(
@@ -81,7 +79,7 @@ impl<T: KeyLayoutMapper> TokenProcessor for WavProcessor<T> {
     }
 }
 
-impl<T: KeyLayoutMapper> WavProcessor<T> {
+impl WavProcessor {
     fn on_header(
         &self,
         name: &str,
@@ -188,9 +186,9 @@ impl<T: KeyLayoutMapper> WavProcessor<T> {
         }
         if name.eq_ignore_ascii_case("LNOBJ") {
             let end_id = ObjId::try_from(args, *self.case_sensitive_obj_id.borrow())?;
-            let mut end_note = objects
+            let end_note = objects
                 .notes
-                .pop_latest_of::<T>(end_id)
+                .pop_latest_of(end_id)
                 .ok_or(ParseWarning::UndefinedObject(end_id))?;
             let WavObj {
                 offset, channel_id, ..
@@ -210,30 +208,8 @@ impl<T: KeyLayoutMapper> WavProcessor<T> {
                 ParseWarning::SyntaxError(format!("Cannot find begin note for LNOBJ {end_id:?}"))
             })?;
 
-            let mut begin_note_tuple = begin_note
-                .channel_id
-                .try_into_map::<T>()
-                .ok_or_else(|| {
-                    ParseWarning::SyntaxError(format!(
-                        "channel of specified note for LNOBJ cannot become LN {end_id:?}"
-                    ))
-                })?
-                .as_tuple();
-            begin_note_tuple.1 = NoteKind::Long;
-            begin_note.channel_id = T::from_tuple(begin_note_tuple).to_channel_id();
+            begin_note.ln_end_for = Some(end_note.offset);
             objects.notes.push_note(begin_note);
-
-            let mut end_note_tuple = end_note
-                .channel_id
-                .try_into_map::<T>()
-                .ok_or_else(|| {
-                    ParseWarning::SyntaxError(format!(
-                        "channel of specified note for LNOBJ cannot become LN {end_id:?}"
-                    ))
-                })?
-                .as_tuple();
-            end_note_tuple.1 = NoteKind::Long;
-            end_note.channel_id = T::from_tuple(end_note_tuple).to_channel_id();
             objects.notes.push_note(end_note);
         }
         if name.eq_ignore_ascii_case("WAVCMD") {
@@ -298,7 +274,7 @@ impl<T: KeyLayoutMapper> WavProcessor<T> {
             let (pairs, w) = parse_obj_ids(track, message, &self.case_sensitive_obj_id);
             warnings.extend(w);
             for (time, obj) in pairs {
-                objects.notes.push_bgm::<T>(time, obj);
+                objects.notes.push_bgm(time, obj);
             }
         }
         if let Channel::Note { channel_id } = channel {
@@ -309,6 +285,7 @@ impl<T: KeyLayoutMapper> WavProcessor<T> {
                     offset,
                     channel_id,
                     wav_id: obj,
+                    ln_end_for: None,
                 });
             }
         }

--- a/src/bms/parse/validity.rs
+++ b/src/bms/parse/validity.rs
@@ -4,18 +4,12 @@
 //! the parsing process. It can be used after editing `Bms` in-memory to ensure
 //! referential integrity and basic invariants required for correct playback.
 
-use std::collections::{HashMap, HashSet};
-
 use thiserror::Error;
 
 use crate::bms::{
-    command::{
-        ObjId,
-        channel::{Key, NoteKind, PlayerSide},
-        time::ObjTime,
-    },
-    model::{Bms, obj::WavObj},
-    prelude::{KeyLayoutBeat, KeyLayoutMapper, KeyMapping},
+    command::ObjId,
+    command::channel::{Key, PlayerSide},
+    command::time::ObjTime,
 };
 
 /// Missing-related validity entries.
@@ -27,6 +21,9 @@ pub enum ValidityMissing {
     #[error("Missing WAV definition for note object id: {0:?}")]
     WavForNote(ObjId),
     /// A BGM references an [`ObjId`] without a corresponding `#WAV` definition.
+    ///
+    /// Note: This variant is currently not produced by [`BmsProcessor::check_validity`](crate::chart::process::bms::BmsProcessor::check_validity).
+    /// It is reserved for future use when BGM-specific WAV missing checks are implemented.
     #[error("Missing WAV definition for BGM object id: {0:?}")]
     WavForBgm(ObjId),
     /// A BGA change references an [`ObjId`] without a corresponding `#BMP`/`#EXBMP` definition.
@@ -118,206 +115,6 @@ pub struct ValidityCheckOutput {
     pub invalid: Vec<ValidityInvalid>,
 }
 
-impl Bms {
-    /// Validate the internal consistency of `Bms` after parsing or manual edits.
-    ///
-    /// This performs basic referential integrity checks and data invariants that
-    /// are required for correct playback, separate from parse-time checks.
-    pub fn check_validity(&self) -> ValidityCheckOutput {
-        let missing = self.check_missing();
-        let invalid = self.check_invalid();
-        ValidityCheckOutput { missing, invalid }
-    }
-
-    fn check_missing(&self) -> Vec<ValidityMissing> {
-        let mut missing = vec![];
-        // 1) Check notes reference valid WAV ids.
-        for obj_id in self.wav.notes.all_notes().map(|obj| &obj.wav_id) {
-            if !self.wav.wav_files.contains_key(obj_id) {
-                missing.push(ValidityMissing::WavForNote(*obj_id));
-            }
-        }
-
-        // 2) Check BGAs reference valid BMP ids.
-        for bga_obj in self.bmp.bga_changes.values() {
-            if !self.bmp.bmp_files.contains_key(&bga_obj.id) {
-                missing.push(ValidityMissing::BmpForBga(bga_obj.id));
-            }
-        }
-
-        // 3) Check BPM change ids used in messages have corresponding #BPMxx definitions.
-        for id in &self.bpm.bpm_change_ids_used {
-            if !self.bpm.bpm_defs.contains_key(id) {
-                missing.push(ValidityMissing::BpmChangeDef(*id));
-            }
-        }
-
-        // 4) Check STOP ids used in messages have corresponding #STOPxx definitions.
-        for id in &self.stop.stop_ids_used {
-            if !self.stop.stop_defs.contains_key(id) {
-                missing.push(ValidityMissing::StopDef(*id));
-            }
-        }
-        missing
-    }
-
-    fn check_invalid(&self) -> Vec<ValidityInvalid> {
-        let mut invalid = vec![];
-
-        // Placement/overlap checks for notes on lanes.
-        //      - Playable notes in section 000
-        //      - Overlap: visible single vs single (same time, same lane)
-        //      - Overlap: visible single within long interval (same lane)
-        //      - Overlap: landmine vs single (same time, same lane)
-        //      - Overlap: landmine within long interval -> warn once at long start
-        let mut lane_to_notes: HashMap<Key, Vec<&WavObj>> = HashMap::new();
-        for obj in self.wav.notes.all_notes() {
-            // Visible note in section 000 (track index 0)
-            let Some(map) = KeyLayoutBeat::from_channel_id(obj.channel_id) else {
-                continue;
-            };
-            if map.kind().is_playable() && obj.offset.track().0 == 0 {
-                invalid.push(ValidityInvalid::PlayableNoteInTrackZero {
-                    side: map.side(),
-                    key: map.key(),
-                    time: obj.offset,
-                });
-            }
-            lane_to_notes.entry(map.key()).or_default().push(obj);
-        }
-        for (key, objs) in lane_to_notes {
-            if objs.is_empty() {
-                continue;
-            }
-            // Sort by time
-            let mut lane_objs = objs;
-            lane_objs.sort_unstable_by_key(|o| o.offset);
-
-            // Build LN intervals by pairing consecutive Long notes
-            let long_times: Vec<ObjTime> = lane_objs
-                .iter()
-                .filter_map(|o| {
-                    let map = KeyLayoutBeat::from_channel_id(o.channel_id)?;
-                    (map.kind() == NoteKind::Long).then_some(o.offset)
-                })
-                .collect();
-
-            // Overlap single vs single at the same time
-            let mut single_offsets = HashSet::new();
-            for (single_obj, map) in lane_objs
-                .iter()
-                .filter_map(|obj| {
-                    KeyLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
-                })
-                .filter(|(_, map)| map.kind() == NoteKind::Visible)
-            {
-                if !single_offsets.insert(single_obj.offset) {
-                    invalid.push(ValidityInvalid::OverlapVisibleSingleWithSingle {
-                        side: map.side(),
-                        key,
-                        time: single_obj.offset,
-                    });
-                }
-            }
-
-            // Overlap landmine vs single at the same time
-            for (landmine_obj, map) in lane_objs
-                .iter()
-                .filter_map(|obj| {
-                    KeyLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
-                })
-                .filter(|(_, map)| map.kind() == NoteKind::Landmine)
-            {
-                if single_offsets.contains(&landmine_obj.offset) {
-                    invalid.push(ValidityInvalid::OverlapLandmineWithSingle {
-                        side: map.side(),
-                        key,
-                        time: landmine_obj.offset,
-                    });
-                }
-            }
-
-            // Helper: check if a time is within [s, e]
-            let time_overlaps_any_ln = |t: ObjTime| -> Option<(ObjTime, ObjTime)> {
-                // Early return if no long notes exist
-                if long_times.is_empty() {
-                    return None;
-                }
-                // Use binary search on sorted long_times to find the insertion point for t
-                let pos = long_times.partition_point(|&x| x < t);
-
-                // Check if we're exactly at a long note time
-                if long_times.get(pos).copied() == Some(t) {
-                    if pos % 2 == 0 {
-                        let end = long_times.get(pos + 1).copied()?;
-                        return Some((t, end));
-                    }
-
-                    if pos > 0 {
-                        let start = long_times.get(pos - 1).copied()?;
-                        if start == t {
-                            return Some((start, t));
-                        }
-                    }
-                    return None;
-                }
-
-                if pos % 2 == 1 {
-                    let start = long_times.get(pos - 1).copied()?;
-                    let end = long_times.get(pos).copied()?;
-                    if start <= t {
-                        return Some((start, end));
-                    }
-                }
-
-                None
-            };
-
-            // Overlap single vs long: any visible single inside any LN interval
-            for (single_obj, map) in lane_objs
-                .iter()
-                .filter_map(|obj| {
-                    KeyLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
-                })
-                .filter(|(_, map)| map.kind() == NoteKind::Visible)
-            {
-                if let Some((start, end)) = time_overlaps_any_ln(single_obj.offset) {
-                    invalid.push(ValidityInvalid::OverlapVisibleSingleWithLong {
-                        side: map.side(),
-                        key,
-                        time: single_obj.offset,
-                        ln_start: start,
-                        ln_end: end,
-                    });
-                }
-            }
-
-            // Landmine vs long: warn once per LN interval at the long start
-            // if any landmine appears inside that interval (including at start).
-            let mut warned_ln_intervals: HashSet<(ObjTime, ObjTime)> = HashSet::new();
-            for (landmine_obj, map) in lane_objs
-                .iter()
-                .filter_map(|obj| {
-                    KeyLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
-                })
-                .filter(|(_, map)| map.kind() == NoteKind::Landmine)
-            {
-                if let Some((start, end)) = time_overlaps_any_ln(landmine_obj.offset)
-                    && warned_ln_intervals.insert((start, end))
-                {
-                    invalid.push(ValidityInvalid::OverlapsLandmineLongAtStart {
-                        side: map.side(),
-                        key,
-                        ln_start: start,
-                        ln_end: end,
-                    });
-                }
-            }
-        }
-        invalid
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
@@ -325,14 +122,19 @@ mod tests {
     use crate::bms::{
         command::{
             ObjId,
-            channel::{Key, NoteKind, PlayerSide},
+            channel::{
+                Key, NoteKind, PlayerSide,
+                mapper::{KeyLayoutBeat, KeyLayoutMapper, KeyMapping},
+            },
             time::ObjTime,
         },
         model::{
+            Bms,
             notes::Notes,
             obj::{BgaLayer, BgaObj, WavObj},
         },
     };
+    use crate::chart::process::bms::BmsProcessor;
 
     fn t(track: u64, num: u64, den: u64) -> ObjTime {
         ObjTime::new(track, num, den).expect("denominator should be non-zero")
@@ -350,10 +152,11 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id,
+            ln_end_for: None,
         });
         bms.wav.notes = notes;
         // No WAV defined for id
-        let out = bms.check_validity();
+        let out = BmsProcessor::check_validity::<KeyLayoutBeat>(&bms);
         assert!(out.missing.contains(&ValidityMissing::WavForNote(id)));
     }
 
@@ -370,7 +173,7 @@ mod tests {
                 layer: BgaLayer::Base,
             },
         );
-        let out = bms.check_validity();
+        let out = BmsProcessor::check_validity::<KeyLayoutBeat>(&bms);
         assert!(out.missing.contains(&ValidityMissing::BmpForBga(id)));
     }
 
@@ -385,10 +188,11 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id,
+            ln_end_for: None,
         });
         bms.wav.notes = notes;
 
-        let out = bms.check_validity();
+        let out = BmsProcessor::check_validity::<KeyLayoutBeat>(&bms);
         assert!(out.invalid.iter().any(|e| matches!(
             e,
             ValidityInvalid::PlayableNoteInTrackZero { time: t0, side: PlayerSide::Player1, key: Key::Key(1) } if *t0 == time
@@ -407,16 +211,18 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id1,
+            ln_end_for: None,
         });
         notes.push_note(WavObj {
             offset: time,
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id2,
+            ln_end_for: None,
         });
         bms.wav.notes = notes;
 
-        let out = bms.check_validity();
+        let out = BmsProcessor::check_validity::<KeyLayoutBeat>(&bms);
         assert!(out.invalid.iter().any(|e| matches!(
             e,
             ValidityInvalid::OverlapVisibleSingleWithSingle { time: t0, side: PlayerSide::Player1, key: Key::Key(1) } if *t0 == time
@@ -439,6 +245,7 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_s,
+            ln_end_for: None,
         });
         // LN end
         notes.push_note(WavObj {
@@ -446,6 +253,7 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_e,
+            ln_end_for: None,
         });
         // Visible inside LN interval
         notes.push_note(WavObj {
@@ -453,10 +261,11 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_vis,
+            ln_end_for: None,
         });
         bms.wav.notes = notes;
 
-        let out = bms.check_validity();
+        let out = BmsProcessor::check_validity::<KeyLayoutBeat>(&bms);
         assert!(out.invalid.iter().any(|e| matches!(
             e,
             ValidityInvalid::OverlapVisibleSingleWithLong { side: PlayerSide::Player1, key: Key::Key(1), time: t0, ln_start: s, ln_end: e } if *t0 == vis_time && *s == ln_start && *e == ln_end
@@ -479,12 +288,14 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_s,
+            ln_end_for: None,
         });
         notes.push_note(WavObj {
             offset: ln_end,
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_e,
+            ln_end_for: None,
         });
         // Landmine inside the LN
         notes.push_note(WavObj {
@@ -492,10 +303,11 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Landmine, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_mine,
+            ln_end_for: None,
         });
         bms.wav.notes = notes;
 
-        let out = bms.check_validity();
+        let out = BmsProcessor::check_validity::<KeyLayoutBeat>(&bms);
         assert!(out.invalid.iter().any(|e| matches!(
             e,
             ValidityInvalid::OverlapsLandmineLongAtStart { side: PlayerSide::Player1, key: Key::Key(1), ln_start: s, ln_end: e } if *s == ln_start && *e == ln_end
@@ -514,16 +326,18 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_vis,
+            ln_end_for: None,
         });
         notes.push_note(WavObj {
             offset: time,
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Landmine, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_mine,
+            ln_end_for: None,
         });
         bms.wav.notes = notes;
 
-        let out = bms.check_validity();
+        let out = BmsProcessor::check_validity::<KeyLayoutBeat>(&bms);
         assert!(out.invalid.iter().any(|e| matches!(
             e,
             ValidityInvalid::OverlapLandmineWithSingle { time: t0, side: PlayerSide::Player1, key: Key::Key(1) } if *t0 == time
@@ -546,12 +360,14 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_start,
+            ln_end_for: None,
         });
         notes.push_note(WavObj {
             offset: zero_length_time, // Same time - zero length
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_end,
+            ln_end_for: None,
         });
 
         // Visible note at the same time as zero-length LN
@@ -560,12 +376,12 @@ mod tests {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_vis,
+            ln_end_for: None,
         });
 
         bms.wav.notes = notes;
 
-        let out = bms.check_validity();
-        // This should detect the overlap, but currently fails due to the bug
+        let out = BmsProcessor::check_validity::<KeyLayoutBeat>(&bms);
         assert!(
             out.invalid.iter().any(|e| matches!(
                 e,

--- a/src/bms/prelude.rs
+++ b/src/bms/prelude.rs
@@ -14,11 +14,6 @@ pub use super::{
         JudgeLevel, LnMode, LnType, ObjId, ObjIdManager, PlayerMode, PoorMode, Volume,
         channel::{
             Channel, Key, NoteChannelId, NoteKind, PlayerSide,
-            converter::{
-                KeyConverter, KeyMappingConvertFlip, KeyMappingConvertLaneRandomShuffle,
-                KeyMappingConvertLaneRotateShuffle, KeyMappingConvertMirror,
-                PlayerSideKeyConverter,
-            },
             mapper::{
                 KeyLayoutBeat, KeyLayoutBeatNanasi, KeyLayoutDscOctFp, KeyLayoutMapper,
                 KeyLayoutPms, KeyLayoutPmsBmeType, KeyMapping,

--- a/src/bmson/bmson_to_bms.rs
+++ b/src/bmson/bmson_to_bms.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use crate::{
     bms::{command::string_value::StringValue, prelude::*},
     bmson::{BgaId, Bmson, pulse::PulseNumber},
+    chart::process::bms::BmsProcessor,
 };
 
 /// Warnings that occur during conversion from `Bmson` to `Bms`.
@@ -187,6 +188,7 @@ impl Bms {
                     offset: time,
                     channel_id: KeyLayoutBeat::new(side, kind, key).to_channel_id(),
                     wav_id: obj_id,
+                    ln_end_for: None,
                 };
                 bms.wav.notes.push_note(obj);
             }
@@ -209,6 +211,7 @@ impl Bms {
                     offset: time,
                     channel_id: KeyLayoutBeat::new(side, NoteKind::Landmine, key).to_channel_id(),
                     wav_id: obj_id,
+                    ln_end_for: None,
                 };
                 bms.wav.notes.push_note(obj);
             }
@@ -231,6 +234,7 @@ impl Bms {
                     offset: time,
                     channel_id: KeyLayoutBeat::new(side, NoteKind::Invisible, key).to_channel_id(),
                     wav_id: obj_id,
+                    ln_end_for: None,
                 };
                 bms.wav.notes.push_note(obj);
             }
@@ -306,7 +310,7 @@ impl Bms {
         let PlayingCheckOutput {
             playing_warnings,
             playing_errors,
-        } = bms.check_playing::<KeyLayoutBeat>();
+        } = BmsProcessor::check_playing::<KeyLayoutBeat>(&bms);
 
         BmsonToBmsOutput {
             bms,

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -64,6 +64,8 @@
 
 pub mod event;
 
+pub mod key;
+
 pub mod player;
 
 pub mod prelude;

--- a/src/chart/key.rs
+++ b/src/chart/key.rs
@@ -1,0 +1,3 @@
+//! Key layout mapping types for chart processing.
+
+pub mod converter;

--- a/src/chart/key/converter.rs
+++ b/src/chart/key/converter.rs
@@ -2,19 +2,19 @@
 
 use std::collections::HashMap;
 
-use super::{Key, PlayerSide};
+use crate::bms::command::channel::{Key, PlayerSide};
 use crate::bms::rng::JavaRandom;
 
-/// A trait for converting [`super::Key`]s in different layouts.
+/// A trait for converting [`Key`]s in different layouts.
 ///
 /// This trait provides a simple interface for converting keys without considering player sides.
 /// It operates on single keys, making it suitable for key-only transformations.
 pub trait KeyConverter {
-    /// Convert a single [`super::Key`] to another key layout.
+    /// Convert a single [`Key`] to another key layout.
     fn convert(&mut self, key: Key) -> Key;
 }
 
-/// A trait for converting [`super::PlayerSide`] and [`super::Key`] pairs in different layouts.
+/// A trait for converting [`PlayerSide`] and [`Key`] pairs in different layouts.
 ///
 /// This trait provides an interface for converting (`PlayerSide`, Key) pairs,
 /// making it suitable for transformations that need to consider both player side and key.
@@ -24,7 +24,7 @@ pub trait PlayerSideKeyConverter {
 }
 
 impl KeyMappingConvertMirror {
-    /// Create a new [`KeyMappingConvertMirror`] with the given [`super::Key`]s.
+    /// Create a new [`KeyMappingConvertMirror`] with the given [`Key`]s.
     #[must_use]
     pub const fn new(keys: Vec<Key>) -> Self {
         Self { keys }
@@ -34,7 +34,7 @@ impl KeyMappingConvertMirror {
 /// Mirror the keys within the specified key list.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KeyMappingConvertMirror {
-    /// A list of [`super::Key`]s to mirror. Usually, it should be the keys that actually used in the song.
+    /// A list of [`Key`]s to mirror. Usually, it should be the keys that actually used in the song.
     keys: Vec<Key>,
 }
 
@@ -55,12 +55,12 @@ impl KeyConverter for KeyMappingConvertMirror {
 /// A modifier that rotates the lanes of keys.
 #[derive(Debug, Clone)]
 pub struct KeyMappingConvertLaneRotateShuffle {
-    /// A map of [`super::Key`]s to their new [`super::Key`]s.
+    /// A map of [`Key`]s to their new [`Key`]s.
     arrangement: HashMap<Key, Key>,
 }
 
 impl KeyMappingConvertLaneRotateShuffle {
-    /// Create a new [`KeyMappingConvertLaneRotateShuffle`] with the given [`super::Key`]s and seed.
+    /// Create a new [`KeyMappingConvertLaneRotateShuffle`] with the given [`Key`]s and seed.
     #[must_use]
     pub fn new(keys: &[Key], seed: i64) -> Self {
         Self {
@@ -109,12 +109,12 @@ impl KeyConverter for KeyMappingConvertLaneRotateShuffle {
 /// Its action is similar to beatoraja's lane shuffle.
 #[derive(Debug, Clone)]
 pub struct KeyMappingConvertLaneRandomShuffle {
-    /// A map of [`super::Key`]s to their new [`super::Key`]s.
+    /// A map of [`Key`]s to their new [`Key`]s.
     arrangement: HashMap<Key, Key>,
 }
 
 impl KeyMappingConvertLaneRandomShuffle {
-    /// Create a new [`KeyMappingConvertLaneRandomShuffle`] with the given [`super::Key`]s and seed.
+    /// Create a new [`KeyMappingConvertLaneRandomShuffle`] with the given [`Key`]s and seed.
     #[must_use]
     pub fn new(keys: &[Key], seed: i64) -> Self {
         Self {

--- a/src/chart/prelude.rs
+++ b/src/chart/prelude.rs
@@ -23,6 +23,17 @@ pub use strict_num_extended::NonNegativeF64;
 // Re-export event types
 pub use super::event::{ChartEvent, PlayheadEvent};
 
+// Re-export key converter types
+pub use super::key::converter::{
+    KeyConverter, KeyMappingConvertFlip, KeyMappingConvertLaneRandomShuffle,
+    KeyMappingConvertLaneRotateShuffle, KeyMappingConvertMirror, PlayerSideKeyConverter,
+};
+
+// Re-export key layout types
+pub use crate::bms::command::channel::mapper::{
+    KeyLayoutBeat, KeyLayoutBeatNanasi, KeyLayoutDscOctFp, KeyLayoutPms, KeyLayoutPmsBmeType,
+};
+
 // Re-export common types from bms module
 pub use crate::bms::prelude::{BgaLayer, Key, NoteKind, PlayerSide};
 

--- a/src/chart/process/bms.rs
+++ b/src/chart/process/bms.rs
@@ -9,8 +9,15 @@ use std::{
 use itertools::Itertools;
 use strict_num_extended::{FinF64, PositiveF64};
 
+use std::collections::HashSet;
+
+use crate::bms::command::channel::mapper::KeyLayoutMapper;
+use crate::bms::command::channel::{Key, NoteKind, PlayerSide};
 use crate::bms::command::string_value::StringValue;
-use crate::bms::parse::check_playing::PlayingError;
+use crate::bms::command::time::ObjTime;
+use crate::bms::model::obj::WavObj;
+use crate::bms::parse::check_playing::{PlayingCheckOutput, PlayingError, PlayingWarning};
+use crate::bms::parse::validity::{ValidityCheckOutput, ValidityInvalid, ValidityMissing};
 use crate::bms::prelude::*;
 use crate::chart::event::{ChartEvent, FlowEvent, PlayheadEvent};
 use crate::chart::process::{
@@ -198,6 +205,208 @@ impl BmsProcessor {
         let kind = map.kind();
         Some((side, key, kind))
     }
+
+    /// Validate the internal consistency of `Bms` after parsing or manual edits.
+    ///
+    /// This performs basic referential integrity checks and data invariants that
+    /// are required for correct playback, separate from parse-time checks.
+    pub fn check_validity<T: KeyLayoutMapper>(bms: &Bms) -> ValidityCheckOutput {
+        let missing = check_missing(bms);
+        let invalid = check_invalid::<T>(bms);
+        ValidityCheckOutput { missing, invalid }
+    }
+
+    /// Check for playing warnings and errors based on the parsed BMS data.
+    pub fn check_playing<T: KeyLayoutMapper>(bms: &Bms) -> PlayingCheckOutput {
+        let mut playing_warnings = Vec::new();
+        let mut playing_errors = Vec::new();
+
+        if bms.judge.total.is_none() {
+            playing_warnings.push(PlayingWarning::TotalUndefined);
+        }
+
+        if bms.bpm.bpm.is_none() {
+            if bms.bpm.bpm_changes.is_empty() {
+                playing_errors.push(PlayingError::BpmUndefined);
+            } else {
+                playing_warnings.push(PlayingWarning::StartBpmUndefined);
+            }
+        }
+
+        if bms.wav.notes.is_empty() {
+            playing_errors.push(PlayingError::NoNotes);
+        } else {
+            let has_displayable = notes_displayables::<T>(&bms.wav.notes).next().is_some();
+            if !has_displayable {
+                playing_warnings.push(PlayingWarning::NoDisplayableNotes);
+            }
+
+            let has_playable = notes_playables::<T>(&bms.wav.notes).next().is_some();
+            if !has_playable {
+                playing_warnings.push(PlayingWarning::NoPlayableNotes);
+            }
+        }
+
+        PlayingCheckOutput {
+            playing_warnings,
+            playing_errors,
+        }
+    }
+}
+
+fn check_missing(bms: &Bms) -> Vec<ValidityMissing> {
+    let mut missing = vec![];
+    for obj_id in bms.wav.notes.all_notes().map(|obj| &obj.wav_id) {
+        if !bms.wav.wav_files.contains_key(obj_id) {
+            missing.push(ValidityMissing::WavForNote(*obj_id));
+        }
+    }
+
+    for bga_obj in bms.bmp.bga_changes.values() {
+        if !bms.bmp.bmp_files.contains_key(&bga_obj.id) {
+            missing.push(ValidityMissing::BmpForBga(bga_obj.id));
+        }
+    }
+
+    for id in &bms.bpm.bpm_change_ids_used {
+        if !bms.bpm.bpm_defs.contains_key(id) {
+            missing.push(ValidityMissing::BpmChangeDef(*id));
+        }
+    }
+
+    for id in &bms.stop.stop_ids_used {
+        if !bms.stop.stop_defs.contains_key(id) {
+            missing.push(ValidityMissing::StopDef(*id));
+        }
+    }
+    missing
+}
+
+fn check_invalid<T: KeyLayoutMapper>(bms: &Bms) -> Vec<ValidityInvalid> {
+    let mut invalid = vec![];
+
+    let mut lane_to_notes: HashMap<Key, Vec<&WavObj>> = HashMap::new();
+    for obj in bms.wav.notes.all_notes() {
+        let Some(map) = T::from_channel_id(obj.channel_id) else {
+            continue;
+        };
+        if map.kind().is_playable() && obj.offset.track().0 == 0 {
+            invalid.push(ValidityInvalid::PlayableNoteInTrackZero {
+                side: map.side(),
+                key: map.key(),
+                time: obj.offset,
+            });
+        }
+        lane_to_notes.entry(map.key()).or_default().push(obj);
+    }
+    for (key, objs) in lane_to_notes {
+        if objs.is_empty() {
+            continue;
+        }
+        let mut lane_objs = objs;
+        lane_objs.sort_unstable_by_key(|o| o.offset);
+
+        // Single pass: bucket by kind, collect long times
+        let mut long_times: Vec<ObjTime> = Vec::new();
+        let mut visibles: Vec<(&WavObj, PlayerSide)> = Vec::new();
+        let mut landmines: Vec<(&WavObj, PlayerSide)> = Vec::new();
+        for obj in &lane_objs {
+            let Some(map) = T::from_channel_id(obj.channel_id) else {
+                continue;
+            };
+            match map.kind() {
+                NoteKind::Long => long_times.push(obj.offset),
+                NoteKind::Visible => visibles.push((obj, map.side())),
+                NoteKind::Landmine => landmines.push((obj, map.side())),
+                NoteKind::Invisible => {}
+            }
+        }
+
+        // Check visible single overlap with single
+        let mut single_offsets = HashSet::new();
+        for (obj, side) in &visibles {
+            if !single_offsets.insert(obj.offset) {
+                invalid.push(ValidityInvalid::OverlapVisibleSingleWithSingle {
+                    side: *side,
+                    key,
+                    time: obj.offset,
+                });
+            }
+        }
+
+        // Check landmine overlap with single
+        for (obj, side) in &landmines {
+            if single_offsets.contains(&obj.offset) {
+                invalid.push(ValidityInvalid::OverlapLandmineWithSingle {
+                    side: *side,
+                    key,
+                    time: obj.offset,
+                });
+            }
+        }
+
+        // LN overlap helper
+        let time_overlaps_any_ln = |t: ObjTime| -> Option<(ObjTime, ObjTime)> {
+            if long_times.is_empty() {
+                return None;
+            }
+            let pos = long_times.partition_point(|&x| x < t);
+
+            if long_times.get(pos).copied() == Some(t) {
+                if pos % 2 == 0 {
+                    let end = long_times.get(pos + 1).copied()?;
+                    return Some((t, end));
+                }
+
+                if pos > 0 {
+                    let start = long_times.get(pos - 1).copied()?;
+                    if start == t {
+                        return Some((start, t));
+                    }
+                }
+                return None;
+            }
+
+            if pos % 2 == 1 {
+                let start = long_times.get(pos - 1).copied()?;
+                let end = long_times.get(pos).copied()?;
+                if start <= t {
+                    return Some((start, end));
+                }
+            }
+
+            None
+        };
+
+        // Check visible overlap with LN
+        for (obj, side) in &visibles {
+            if let Some((start, end)) = time_overlaps_any_ln(obj.offset) {
+                invalid.push(ValidityInvalid::OverlapVisibleSingleWithLong {
+                    side: *side,
+                    key,
+                    time: obj.offset,
+                    ln_start: start,
+                    ln_end: end,
+                });
+            }
+        }
+
+        // Check landmine overlap with LN
+        let mut warned_ln_intervals: HashSet<(ObjTime, ObjTime)> = HashSet::new();
+        for (obj, side) in &landmines {
+            if let Some((start, end)) = time_overlaps_any_ln(obj.offset)
+                && warned_ln_intervals.insert((start, end))
+            {
+                invalid.push(ValidityInvalid::OverlapsLandmineLongAtStart {
+                    side: *side,
+                    key,
+                    ln_start: start,
+                    ln_end: end,
+                });
+            }
+        }
+    }
+    invalid
 }
 
 /// Y coordinate memoization for efficient position calculation.
@@ -376,6 +585,14 @@ impl AllEventsIndex {
             .sorted_by(|(y1, _), (y2, _)| y1.cmp(y2))
             .collect();
 
+        let ln_end_markers: HashSet<(ObjTime, NoteChannelId)> = note_events
+            .iter()
+            .filter_map(|(_, obj)| {
+                obj.ln_end_for
+                    .map(|end_offset| (end_offset, obj.channel_id))
+            })
+            .collect();
+
         // Use ordered Vec instead of HashMap since f64 doesn't implement Hash
         // and NonNegativeF64 doesn't implement Hash either
         let mut zero_length_key_tracker: Vec<(YCoordinate, PlayerSide, Key, usize)> = Vec::new();
@@ -413,6 +630,10 @@ impl AllEventsIndex {
             std::collections::HashSet::new();
 
         for (i, (y, obj)) in note_events.iter().enumerate() {
+            if obj.ln_end_for.is_none() && ln_end_markers.contains(&(obj.offset, obj.channel_id)) {
+                continue;
+            }
+
             let is_zero_length_section = y_memo.zero_length_tracks.contains(&obj.offset.track());
             let lane = BmsProcessor::lane_of_channel_id::<T>(obj.channel_id);
             let should_include = match lane {
@@ -753,6 +974,121 @@ pub fn precompute_activate_times(
     Ok(AllEventsIndex::new(new_map))
 }
 
+/// Returns all the playable notes in the score for the given key layout.
+///
+/// # Note
+/// This iterator may include dangling objects (objects with null `wav_id`) that reference
+/// non-existent WAV files. These dangling objects represent invalid or unassigned notes
+/// and do not affect musical playback.
+/// They may originate from parsing issues in the original BMS file or from user modifications
+/// to the Notes object.
+///
+/// To filter out dangling objects, use:
+/// ```rust
+/// # use bms_rs::bms::prelude::*;
+/// # use bms_rs::chart::process::bms::notes_playables;
+/// # use bms_rs::chart::prelude::KeyLayoutBeat;
+/// # let notes = Notes::default();
+/// notes_playables::<KeyLayoutBeat>(&notes).filter(|obj| !obj.wav_id.is_null())
+/// # ;
+/// ```
+pub fn notes_playables<T: KeyLayoutMapper>(notes: &Notes) -> impl Iterator<Item = &WavObj> {
+    notes.all_notes().filter(|obj| {
+        obj.channel_id
+            .try_into_map::<T>()
+            .is_some_and(|map| map.kind().is_playable())
+    })
+}
+
+/// Returns all the displayable notes in the score for the given key layout.
+///
+/// # Note
+/// This iterator may include dangling objects (objects with null `wav_id`) that reference
+/// non-existent WAV files. These dangling objects represent invalid or unassigned notes
+/// and do not affect musical playback.
+/// They may originate from parsing issues in the original BMS file or from user modifications
+/// to the Notes object.
+///
+/// To filter out dangling objects, use:
+/// ```rust
+/// # use bms_rs::bms::prelude::*;
+/// # use bms_rs::chart::process::bms::notes_displayables;
+/// # use bms_rs::chart::prelude::KeyLayoutBeat;
+/// # let notes = Notes::default();
+/// notes_displayables::<KeyLayoutBeat>(&notes).filter(|obj| !obj.wav_id.is_null())
+/// # ;
+/// ```
+pub fn notes_displayables<T: KeyLayoutMapper>(notes: &Notes) -> impl Iterator<Item = &WavObj> {
+    notes.all_notes().filter(|obj| {
+        obj.channel_id
+            .try_into_map::<T>()
+            .is_some_and(|map| map.kind().is_displayable())
+    })
+}
+
+/// Returns all the BGM notes in the score for the given key layout.
+///
+/// BGM notes are defined as notes whose channel is either:
+/// - The BGM channel (`01`), or
+/// - Not recognized by the current `KeyLayoutMapper` (treated as BGM by default).
+///
+/// This means unrecognized channels from a custom `KeyLayoutMapper` will also be
+/// included. If you need strict BGM-only filtering, check `NoteChannelId::bgm()` directly.
+///
+/// # Note
+/// This iterator may include dangling objects (objects with null `wav_id`) that reference
+/// non-existent WAV files. These dangling objects represent invalid or unassigned notes
+/// and do not affect musical playback.
+/// They may originate from parsing issues in the original BMS file or from user modifications
+/// to the Notes object.
+///
+/// To filter out dangling objects, use:
+/// ```rust
+/// # use bms_rs::bms::prelude::*;
+/// # use bms_rs::chart::process::bms::notes_bgms;
+/// # use bms_rs::chart::prelude::KeyLayoutBeat;
+/// # let notes = Notes::default();
+/// notes_bgms::<KeyLayoutBeat>(&notes).filter(|obj| !obj.wav_id.is_null())
+/// # ;
+/// ```
+pub fn notes_bgms<T: KeyLayoutMapper>(notes: &Notes) -> impl Iterator<Item = &WavObj> {
+    notes.all_notes().filter(|obj| {
+        obj.channel_id
+            .try_into_map::<T>()
+            .is_none_or(|map| !map.kind().is_displayable())
+    })
+}
+
+/// Gets the time of last playable object for the given key layout.
+#[must_use]
+pub fn last_playable_time<T: KeyLayoutMapper>(notes: &Notes) -> Option<ObjTime> {
+    notes
+        .notes_in(..)
+        .rev()
+        .find(|(_, obj)| {
+            obj.channel_id
+                .try_into_map::<T>()
+                .is_some_and(|map| map.kind().is_displayable())
+        })
+        .map(|(_, obj)| obj.offset)
+}
+
+/// Gets the time of last BGM object for the given key layout.
+///
+/// You can't use this to find the length of music. Because this doesn't consider that the length of sound. And visible notes may ring after all BGMs.
+#[must_use]
+pub fn last_bgm_time<T: KeyLayoutMapper>(notes: &Notes) -> Option<ObjTime> {
+    notes
+        .notes_in(..)
+        .rev()
+        .find(|(_, obj)| {
+            obj.channel_id
+                .try_into_map::<T>()
+                .is_none_or(|map| !map.kind().is_displayable())
+        })
+        .map(|(_, obj)| obj.offset)
+}
+
 /// Generate a static chart event for a BMS note object.
 ///
 /// This function converts a BMS `WavObj` into a `ChartEvent` with all necessary
@@ -776,11 +1112,33 @@ pub fn event_for_note_static<T: KeyLayoutMapper>(
     obj: &WavObj,
 ) -> ChartEvent {
     let y = y_memo.get_y(obj.offset);
-    let lane = BmsProcessor::lane_of_channel_id::<T>(obj.channel_id);
     let wav_id = Some(WavId::from(obj.wav_id.as_u16() as usize));
+
+    if let Some(end_offset) = obj.ln_end_for {
+        let lane = match T::from_channel_id(obj.channel_id) {
+            Some(l) => l,
+            None => return ChartEvent::Bgm { wav_id },
+        };
+        let side = lane.side();
+        let key = lane.key();
+        let end_y = y_memo.get_y(end_offset);
+        let length = NonNegativeF64::new((end_y - y).as_f64()).unwrap_or(NonNegativeF64::ZERO);
+        return ChartEvent::Note {
+            side,
+            key,
+            kind: NoteKind::Long,
+            wav_id,
+            length: Some(length),
+            continue_play: None,
+        };
+    }
+
+    let lane = BmsProcessor::lane_of_channel_id::<T>(obj.channel_id);
     let Some((side, key, kind)) = lane else {
         return ChartEvent::Bgm { wav_id };
     };
+    // TODO: After all WavObj construction paths populate `ln_end_for`, this fallback
+    // path (looking up the next note in the same channel) can be removed.
     let length = (kind == NoteKind::Long)
         .then(|| {
             bms.notes()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //! use rand::{rngs::StdRng, SeedableRng};
 //! use bms_rs::bms::prelude::*;
 //! use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
+//! use bms_rs::chart::process::bms::BmsProcessor;
 //! use num::BigUint;
 //!
 //! let source = std::fs::read_to_string("tests/bms/files/lilith_mx.bms").unwrap();
@@ -58,7 +59,7 @@
 //! );
 //! let bms = parse_output.bms.expect("must be parsed");
 //! // According to [BMS command memo#BEHAVIOR IN GENERAL IMPLEMENTATION](https://hitkey.bms.ms/cmds.htm#BEHAVIOR-IN-GENERAL-IMPLEMENTATION), the newer values are used for the duplicated objects.
-//! let PlayingCheckOutput { playing_warnings, playing_errors } = bms.check_playing::<KeyLayoutBeat>();
+//! let PlayingCheckOutput { playing_warnings, playing_errors } = BmsProcessor::check_playing::<KeyLayoutBeat>(&bms);
 //! assert_eq!(playing_warnings, vec![]);
 //! assert_eq!(playing_errors, vec![]);
 //! println!("Title: {}", bms.music_info.title.as_deref().unwrap_or("Unknown"));

--- a/tests/bms/base_62.rs
+++ b/tests/bms/base_62.rs
@@ -16,10 +16,7 @@ fn test_not_base_62() {
     let ParseOutput {
         bms,
         parse_warnings,
-    } = Bms::from_token_stream::<'_, KeyLayoutBeat, _, _, _>(
-        &tokens,
-        default_config().prompter(AlwaysUseNewer),
-    );
+    } = Bms::from_token_stream::<'_, _, _, _>(&tokens, default_config().prompter(AlwaysUseNewer));
     assert_eq!(parse_warnings, vec![]);
     let bms = bms.expect("no errors");
     eprintln!("{bms:?}");
@@ -47,10 +44,7 @@ fn test_base_62() {
     let ParseOutput {
         bms,
         parse_warnings,
-    } = Bms::from_token_stream::<'_, KeyLayoutBeat, _, _, _>(
-        &tokens,
-        default_config().prompter(AlwaysUseNewer),
-    );
+    } = Bms::from_token_stream::<'_, _, _, _>(&tokens, default_config().prompter(AlwaysUseNewer));
     assert_eq!(parse_warnings, vec![]);
     let bms = bms.expect("no errors");
     eprintln!("{bms:?}");

--- a/tests/bms/control_flow_model.rs
+++ b/tests/bms/control_flow_model.rs
@@ -78,6 +78,7 @@ fn test_nested_random_structure() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                 .to_channel_id(),
             wav_id: ObjId::try_from("22", false).unwrap(),
+            ln_end_for: None,
         }]
     );
     assert_eq!(branch1.sub.randomized.len(), 1);
@@ -111,6 +112,7 @@ fn test_nested_random_structure() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                 .to_channel_id(),
             wav_id: ObjId::try_from("55", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -130,6 +132,7 @@ fn test_nested_random_structure() {
             offset: ObjTime::new(1, 2, 4).unwrap(),
             channel_id: NoteChannelId::try_from(['1', '6']).unwrap(),
             wav_id: ObjId::try_from("66", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -145,6 +148,7 @@ fn test_nested_random_structure() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                 .to_channel_id(),
             wav_id: ObjId::try_from("33", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -295,6 +299,7 @@ fn test_nested_switch_structure() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                 .to_channel_id(),
             wav_id: ObjId::try_from("22", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -327,6 +332,7 @@ fn test_nested_switch_structure() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                 .to_channel_id(),
             wav_id: ObjId::try_from("55", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -346,6 +352,7 @@ fn test_nested_switch_structure() {
             offset: ObjTime::new(1, 2, 4).unwrap(),
             channel_id: NoteChannelId::try_from(['1', '6']).unwrap(),
             wav_id: ObjId::try_from("66", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -361,6 +368,7 @@ fn test_nested_switch_structure() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                 .to_channel_id(),
             wav_id: ObjId::try_from("33", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -659,6 +667,7 @@ fn test_switch_fallthrough_one_skip() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                 .to_channel_id(),
             wav_id: ObjId::try_from("22", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -673,6 +682,7 @@ fn test_switch_fallthrough_one_skip() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                 .to_channel_id(),
             wav_id: ObjId::try_from("33", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -766,6 +776,7 @@ fn test_switch_default_then_case_override() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                 .to_channel_id(),
             wav_id: ObjId::try_from("22", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 
@@ -780,6 +791,7 @@ fn test_switch_default_then_case_override() {
             channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                 .to_channel_id(),
             wav_id: ObjId::try_from("33", false).unwrap(),
+            ln_end_for: None,
         }]
     );
 

--- a/tests/bms/extra_channel.rs
+++ b/tests/bms/extra_channel.rs
@@ -107,10 +107,8 @@ fn test_channel_judge() {
     #001A0:01000200
     #002A0:02000100
     ";
-    let BmsOutput { bms, warnings } = parse_bms::<KeyLayoutBeat, _, _, _>(
-        src,
-        default_config_with_rng(RngMock([BigUint::from(1u64)])),
-    );
+    let BmsOutput { bms, warnings } =
+        parse_bms::<_, _, _>(src, default_config_with_rng(RngMock([BigUint::from(1u64)])));
     let bms = bms.unwrap();
     assert_eq!(
         warnings
@@ -156,10 +154,8 @@ fn test_bga_opacity_channels() {
     #0010D:A0
     #0010E:B0
     ";
-    let BmsOutput { bms, warnings } = parse_bms::<KeyLayoutBeat, _, _, _>(
-        src,
-        default_config_with_rng(RngMock([BigUint::from(1u64)])),
-    );
+    let BmsOutput { bms, warnings } =
+        parse_bms::<_, _, _>(src, default_config_with_rng(RngMock([BigUint::from(1u64)])));
     let bms = bms.unwrap();
     assert_eq!(
         warnings
@@ -243,10 +239,8 @@ fn test_bga_argb_channels() {
     #001A3:03010204
     #001A4:04010203
     ";
-    let BmsOutput { bms, warnings } = parse_bms::<KeyLayoutBeat, _, _, _>(
-        src,
-        default_config_with_rng(RngMock([BigUint::from(1u64)])),
-    );
+    let BmsOutput { bms, warnings } =
+        parse_bms::<_, _, _>(src, default_config_with_rng(RngMock([BigUint::from(1u64)])));
     let bms = bms.unwrap();
     assert_eq!(
         warnings

--- a/tests/bms/files.rs
+++ b/tests/bms/files.rs
@@ -149,14 +149,7 @@ fn test_bemuse_ext() {
     let source = include_str!("files/bemuse_ext.bms");
     let BmsOutput { bms, warnings } = parse_bms(source, default_config());
     let bms = bms.unwrap();
-    assert_eq!(
-        warnings,
-        vec![
-            BmsWarning::PlayingWarning(PlayingWarning::TotalUndefined),
-            BmsWarning::PlayingError(PlayingError::BpmUndefined),
-            BmsWarning::PlayingError(PlayingError::NoNotes)
-        ]
-    );
+    assert_eq!(warnings, vec![]);
 
     // Check header content - this file has minimal header info
     // but should have scrolling and spacing factor changes

--- a/tests/bms/mod.rs
+++ b/tests/bms/mod.rs
@@ -34,7 +34,7 @@ pub fn test_bms_assert_objs(src: &str, rng: impl Rng, expect_objs: impl AsRef<[W
     let ParseOutput {
         bms,
         parse_warnings,
-    } = Bms::from_token_stream::<'_, KeyLayoutBeat, _, _, _>(
+    } = Bms::from_token_stream::<'_, _, _, _>(
         &tokens,
         default_config_with_rng(rng).prompter(AlwaysUseNewer),
     );

--- a/tests/bms/nested_random.rs
+++ b/tests/bms/nested_random.rs
@@ -50,24 +50,28 @@ fn nested_random() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                     .to_channel_id(),
                 wav_id: id55,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -81,12 +85,14 @@ fn nested_random() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
@@ -97,12 +103,14 @@ fn nested_random() {
                 )
                 .to_channel_id(),
                 wav_id: id66,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -116,18 +124,21 @@ fn nested_random() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                     .to_channel_id(),
                 wav_id: id33,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );

--- a/tests/bms/nested_switch.rs
+++ b/tests/bms/nested_switch.rs
@@ -125,24 +125,28 @@ fn nested_switch() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                     .to_channel_id(),
                 wav_id: id55,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -156,12 +160,14 @@ fn nested_switch() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
@@ -172,12 +178,14 @@ fn nested_switch() {
                 )
                 .to_channel_id(),
                 wav_id: id66,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -191,18 +199,21 @@ fn nested_switch() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                     .to_channel_id(),
                 wav_id: id33,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -255,24 +266,28 @@ fn nested_random_in_switch() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                     .to_channel_id(),
                 wav_id: id55,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -286,12 +301,14 @@ fn nested_random_in_switch() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
@@ -302,12 +319,14 @@ fn nested_random_in_switch() {
                 )
                 .to_channel_id(),
                 wav_id: id66,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -321,18 +340,21 @@ fn nested_random_in_switch() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                     .to_channel_id(),
                 wav_id: id33,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -385,24 +407,28 @@ fn nested_switch_in_random() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                     .to_channel_id(),
                 wav_id: id55,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("2 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -416,12 +442,14 @@ fn nested_switch_in_random() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
@@ -432,12 +460,14 @@ fn nested_switch_in_random() {
                 )
                 .to_channel_id(),
                 wav_id: id66,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("2 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -451,18 +481,21 @@ fn nested_switch_in_random() {
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                     .to_channel_id(),
                 wav_id: id33,
+                ln_end_for: None,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
                 channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
+                ln_end_for: None,
             },
         ],
     );
@@ -505,6 +538,7 @@ fn test_switch_insane() {
         channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
             .to_channel_id(),
         wav_id: ObjId::try_from("55", false).unwrap(),
+        ln_end_for: None,
     }];
 
     for rng in [

--- a/tests/bms/playing_conditions.rs
+++ b/tests/bms/playing_conditions.rs
@@ -1,4 +1,5 @@
 use bms_rs::bms::prelude::*;
+use bms_rs::chart::process::bms::BmsProcessor;
 
 #[test]
 fn test_playing_conditions_empty_bms() {
@@ -20,7 +21,7 @@ fn test_playing_conditions_empty_bms() {
     let PlayingCheckOutput {
         playing_warnings,
         playing_errors,
-    } = bms.check_playing::<KeyLayoutBeat>();
+    } = BmsProcessor::check_playing::<KeyLayoutBeat>(&bms);
 
     // Should have warnings and errors for empty BMS
     assert!(playing_warnings.contains(&PlayingWarning::TotalUndefined));
@@ -50,7 +51,7 @@ fn test_playing_conditions_with_bpm_and_notes() {
     let PlayingCheckOutput {
         playing_warnings,
         playing_errors,
-    } = bms.check_playing::<KeyLayoutBeat>();
+    } = BmsProcessor::check_playing::<KeyLayoutBeat>(&bms);
 
     // Should not have any warnings or errors for valid BMS
     assert_eq!(playing_warnings, vec![]);
@@ -88,7 +89,7 @@ fn test_playing_conditions_with_bpm_change_only() {
     let PlayingCheckOutput {
         playing_warnings,
         playing_errors,
-    } = bms.check_playing::<KeyLayoutBeat>();
+    } = BmsProcessor::check_playing::<KeyLayoutBeat>(&bms);
 
     // Should have StartBpmUndefined warning but no BpmUndefined error
     assert_eq!(bms.bpm.bpm, None);
@@ -119,7 +120,7 @@ fn test_playing_conditions_invisible_notes_only() {
     let PlayingCheckOutput {
         playing_warnings,
         playing_errors,
-    } = bms.check_playing::<KeyLayoutBeat>();
+    } = BmsProcessor::check_playing::<KeyLayoutBeat>(&bms);
 
     // Should have both NoDisplayableNotes and NoPlayableNotes warnings
     assert!(playing_warnings.contains(&PlayingWarning::NoDisplayableNotes));

--- a/tests/bms/prelude_test.rs
+++ b/tests/bms/prelude_test.rs
@@ -21,6 +21,7 @@ fn test_prelude_imports() {
         offset: _obj_time,
         channel_id: NoteChannelId::bgm(),
         wav_id: _obj_id,
+        ln_end_for: None,
     };
     let _bga_obj = BgaObj {
         time: _obj_time,

--- a/tests/chart/bms/mod.rs
+++ b/tests/chart/bms/mod.rs
@@ -14,9 +14,8 @@ use super::{MICROSECOND_EPSILON, assert_time_close};
 /// # Panics
 ///
 /// Panics if there are any lex or parse warnings.
-pub fn parse_bms_no_warnings<T, P, R, M>(source: &str, config: ParseConfig<T, P, R, M>) -> Bms
+pub fn parse_bms_no_warnings<P, R, M>(source: &str, config: ParseConfig<P, R, M>) -> Bms
 where
-    T: KeyLayoutMapper,
     P: Prompter,
     R: Rng,
     M: TokenModifier,


### PR DESCRIPTION
Remove KeyLayoutMapper generic param T from ParseConfig and parse_bms, making the parser layout-agnostic. Move check_playing/check_validity from Bms methods to BmsProcessor. Relocate key converter module from bms::command::channel to chart::key. Add WavObj::ln_end_for field and helper functions for note classification.