### PR TITLE
refactor!: reverse module dependencies to `chart` <- `bms/bmson`

### DIFF
--- a/benches/parse_bms.rs
+++ b/benches/parse_bms.rs
@@ -1,9 +1,6 @@
 //! Benchmark for `BMS` file parsing and chart conversion.
 
-use bms_rs::{
-    bms::{default_config, parse_bms},
-    chart::process::bms::BmsProcessor,
-};
+use bms_rs::bms::{default_config, parse_bms, process::BmsProcessor};
 use criterion::{Criterion, Throughput};
 use std::{collections::BTreeMap, sync::LazyLock};
 

--- a/benches/parse_bmson.rs
+++ b/benches/parse_bmson.rs
@@ -1,9 +1,6 @@
 //! Benchmark for `BMSON` file parsing and chart conversion.
 
-use bms_rs::{
-    bmson::{Bmson, parse_bmson},
-    chart::process::bmson::BmsonProcessor,
-};
+use bms_rs::bmson::{Bmson, parse_bmson, process::BmsonProcessor};
 use criterion::{Criterion, Throughput};
 use std::{collections::BTreeMap, sync::LazyLock};
 

--- a/examples/microquad_player.rs
+++ b/examples/microquad_player.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use bms_rs::bms::prelude::*;
+use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 use clap::Parser;
 use gametime::{TimeSpan, TimeStamp};

--- a/src/bms.rs
+++ b/src/bms.rs
@@ -23,6 +23,7 @@ pub mod lex;
 pub mod model;
 pub mod parse;
 pub mod prelude;
+pub mod process;
 pub mod rng;
 pub mod unparse;
 

--- a/src/bms/command/channel.rs
+++ b/src/bms/command/channel.rs
@@ -11,6 +11,9 @@ use thiserror::Error;
 
 use self::mapper::KeyLayoutMapper;
 
+// Import chart types for use in this module
+use crate::chart::types::{Key, NoteKind, PlayerSide};
+
 pub mod converter;
 pub mod mapper;
 
@@ -122,51 +125,6 @@ impl std::fmt::Display for Channel {
             Self::OptionChange => write!(f, "CHANGE_OPTION"),
         }
     }
-}
-
-/// A kind of the note.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum NoteKind {
-    /// A normal note can be seen by the user.
-    Visible,
-    /// A invisible note cannot be played by the user.
-    Invisible,
-    /// A long-press note (LN), requires the user to hold pressing the key.
-    Long,
-    /// A landmine note that treated as POOR judgement when
-    Landmine,
-}
-
-impl NoteKind {
-    /// Returns whether the note is a displayable.
-    #[must_use]
-    pub const fn is_displayable(self) -> bool {
-        !matches!(self, Self::Invisible)
-    }
-
-    /// Returns whether the note is a playable.
-    #[must_use]
-    pub const fn is_playable(self) -> bool {
-        matches!(self, Self::Visible | Self::Long)
-    }
-
-    /// Returns whether the note is a long-press note.
-    #[must_use]
-    pub const fn is_long(self) -> bool {
-        matches!(self, Self::Long)
-    }
-}
-
-/// A side of the player.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum PlayerSide {
-    /// The player 1 side.
-    #[default]
-    Player1,
-    /// The player 2 side.
-    Player2,
 }
 
 /// Error type for parsing [`NoteChannelId`] from string.
@@ -358,78 +316,6 @@ impl From<Channel> for NoteChannelId {
             Channel::Speed => Self([b'S', b'P']),
             Channel::Note { channel_id } => channel_id,
         }
-    }
-}
-
-/// A key of the controller or keyboard.
-///
-/// - Beat 5K/7K/10K/14K:
-/// ```text
-/// |---------|----------------------|
-/// |         |   [K2]  [K4]  [K6]   |
-/// |(Scratch)|[K1]  [K3]  [K5]  [K7]|
-/// |---------|----------------------|
-/// ```
-///
-/// - PMS:
-/// ```text
-/// |----------------------------|
-/// |   [K2]  [K4]  [K6]  [K8]   |
-/// |[K1]  [K3]  [K5]  [K7]  [K9]|
-/// |----------------------------|
-/// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[non_exhaustive]
-pub enum Key {
-    /// The keys for the controller.
-    Key(u8),
-    /// The scratch disk.
-    Scratch(u8),
-    /// The foot pedal.
-    FootPedal,
-    /// The zone that the user can scratch disk freely.
-    /// `17` in BMS-type Player1.
-    FreeZone,
-}
-
-impl Key {
-    /// Returns whether the key expected a piano keyboard.
-    #[must_use]
-    pub const fn is_keyxx(&self) -> bool {
-        matches!(self, Self::Key(_))
-    }
-
-    /// Returns the key number if it's a Key variant.
-    #[must_use]
-    pub const fn key_number(&self) -> Option<u8> {
-        if let Self::Key(n) = self {
-            Some(*n)
-        } else {
-            None
-        }
-    }
-
-    /// Returns the scratch number if it's a Scratch variant.
-    #[must_use]
-    pub const fn scratch_number(&self) -> Option<u8> {
-        if let Self::Scratch(n) = self {
-            Some(*n)
-        } else {
-            None
-        }
-    }
-
-    /// Creates a Key variant with the given number.
-    #[must_use]
-    pub const fn new_key(n: u8) -> Self {
-        Self::Key(n)
-    }
-
-    /// Creates a Scratch variant with the given number.
-    #[must_use]
-    pub const fn new_scratch(n: u8) -> Self {
-        Self::Scratch(n)
     }
 }
 

--- a/src/bms/command/graphics.rs
+++ b/src/bms/command/graphics.rs
@@ -60,31 +60,6 @@ impl From<PixelSize> for (u16, u16) {
     }
 }
 
-/// An alpha-red-gree-blue color data.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Argb {
-    /// A component of alpha.
-    pub alpha: u8,
-    /// A component of red.
-    pub red: u8,
-    /// A component of green.
-    pub green: u8,
-    /// A component of blue.
-    pub blue: u8,
-}
-
-impl Default for Argb {
-    fn default() -> Self {
-        Self {
-            alpha: 255,
-            red: 0,
-            green: 0,
-            blue: 0,
-        }
-    }
-}
-
 /// RGB struct, used for #VIDEOCOLORS and similar commands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/src/bms/command/minor_command.rs
+++ b/src/bms/command/minor_command.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
-use super::{ObjId, graphics::Argb};
+use super::ObjId;
 use crate::bms::command::time::ObjTime;
+use crate::chart::types::Argb;
 
 /// Pan value for `#EXWAV` sound effect.
 /// Range: \[-10000, 10000]. -10000 is leftmost, 10000 is rightmost.

--- a/src/bms/model/bmp.rs
+++ b/src/bms/model/bmp.rs
@@ -8,10 +8,13 @@ use std::{
     path::PathBuf,
 };
 
-use crate::bms::{
-    command::graphics::{Argb, PixelPoint, PixelSize},
-    parse::{Result, prompt::ChannelDuplication},
-    prelude::*,
+use crate::{
+    bms::{
+        command::graphics::{PixelPoint, PixelSize},
+        parse::{Result, prompt::ChannelDuplication},
+        prelude::*,
+    },
+    chart::types::{Argb, BgaLayer},
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/src/bms/model/obj.rs
+++ b/src/bms/model/obj.rs
@@ -8,7 +8,9 @@ use crate::bms::command::{
     time::{ObjTime, Track},
 };
 
-use crate::bms::command::{graphics::Argb, minor_command::SwBgaEvent};
+use crate::bms::command::minor_command::SwBgaEvent;
+use crate::chart::types::Argb;
+use crate::chart::types::BgaLayer;
 
 /// An object playing sound on the score.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -168,23 +170,6 @@ impl Ord for BgaObj {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.time.cmp(&other.time)
     }
-}
-
-/// A layer where the image for BGA to be displayed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[non_exhaustive]
-pub enum BgaLayer {
-    /// The lowest layer.
-    Base,
-    /// Layer which is displayed only if a player missed to play notes.
-    Poor,
-    /// An overlaying layer.
-    Overlay,
-    /// An overlaying layer.
-    ///
-    /// This layer is layered over [`BgaLayer::Overlay`].
-    Overlay2,
 }
 
 impl BgaLayer {

--- a/src/bms/parse/prompt.rs
+++ b/src/bms/parse/prompt.rs
@@ -27,12 +27,10 @@ use crate::bms::model::obj::{
 };
 
 use crate::bms::{
-    command::{
-        graphics::Argb,
-        minor_command::{StpEvent, SwBgaEvent, WavCmdEvent},
-    },
+    command::minor_command::{StpEvent, SwBgaEvent, WavCmdEvent},
     model::obj::{BgaArgbObj, BgaKeyboundObj, BgaOpacityObj, OptionObj, SeekObj},
 };
+use crate::chart::types::Argb;
 
 /// An interface to prompt about handling conflicts on the BMS file.
 pub trait Prompter {

--- a/src/bms/parse/token_processor/bmp.rs
+++ b/src/bms/parse/token_processor/bmp.rs
@@ -34,6 +34,7 @@ use crate::{
         },
         prelude::*,
     },
+    chart::types::{Argb, BgaLayer},
     util::StrExtension,
 };
 

--- a/src/bms/parse/validity.rs
+++ b/src/bms/parse/validity.rs
@@ -9,14 +9,11 @@ use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 
 use crate::bms::{
-    command::{
-        ObjId,
-        channel::{Key, NoteKind, PlayerSide},
-        time::ObjTime,
-    },
+    command::{ObjId, time::ObjTime},
     model::{Bms, obj::WavObj},
     prelude::{KeyLayoutBeat, KeyLayoutMapper, KeyMapping},
 };
+use crate::chart::types::{Key, NoteKind, PlayerSide};
 
 /// Missing-related validity entries.
 #[non_exhaustive]
@@ -323,16 +320,13 @@ mod tests {
 
     use super::*;
     use crate::bms::{
-        command::{
-            ObjId,
-            channel::{Key, NoteKind, PlayerSide},
-            time::ObjTime,
-        },
+        command::{ObjId, time::ObjTime},
         model::{
             notes::Notes,
-            obj::{BgaLayer, BgaObj, WavObj},
+            obj::{BgaObj, WavObj},
         },
     };
+    use crate::chart::types::{BgaLayer, Key, NoteKind, PlayerSide};
 
     fn t(track: u64, num: u64, den: u64) -> ObjTime {
         ObjTime::new(track, num, den).expect("denominator should be non-zero")

--- a/src/bms/prelude.rs
+++ b/src/bms/prelude.rs
@@ -13,7 +13,7 @@ pub use super::{
     command::{
         JudgeLevel, LnMode, LnType, ObjId, ObjIdManager, PlayerMode, PoorMode, Volume,
         channel::{
-            Channel, Key, NoteChannelId, NoteKind, PlayerSide,
+            Channel, NoteChannelId,
             converter::{
                 KeyConverter, KeyMappingConvertFlip, KeyMappingConvertLaneRandomShuffle,
                 KeyMappingConvertLaneRotateShuffle, KeyMappingConvertMirror,
@@ -25,7 +25,7 @@ pub use super::{
             },
             read_channel,
         },
-        graphics::{Argb, PixelPoint, PixelSize, Rgb},
+        graphics::{PixelPoint, PixelSize, Rgb},
         minor_command::{
             ExWavFrequency, ExWavPan, ExWavVolume, ExtChrEvent, StpEvent, SwBgaEvent, WavCmdEvent,
             WavCmdParam,
@@ -46,9 +46,9 @@ pub use super::{
         judge::ExRankDef,
         notes::Notes,
         obj::{
-            BgaArgbObj, BgaKeyboundObj, BgaLayer, BgaObj, BgaOpacityObj, BgmVolumeObj,
-            BpmChangeObj, JudgeObj, KeyVolumeObj, OptionObj, ScrollingFactorObj,
-            SectionLenChangeObj, SeekObj, SpeedObj, StopObj, TextObj, WavObj,
+            BgaArgbObj, BgaKeyboundObj, BgaObj, BgaOpacityObj, BgmVolumeObj, BpmChangeObj,
+            JudgeObj, KeyVolumeObj, OptionObj, ScrollingFactorObj, SectionLenChangeObj, SeekObj,
+            SpeedObj, StopObj, TextObj, WavObj,
         },
         wav::ExWavDef,
     },
@@ -68,6 +68,15 @@ pub use super::{
     parse_bms,
     rng::{Rng, RngMock},
 };
+
+// Re-export process module
+pub use super::process::BmsProcessor;
+
+// Re-export chart event types (including BmsEvent)
+pub use crate::chart::event::BmsEvent;
+
+// Re-export chart types
+pub use crate::chart::types::{Argb, BgaLayer, Key, NoteKind, PlayerSide};
 
 // Re-export related members when `rand` feature is enabled
 #[cfg(feature = "rand")]

--- a/src/bms/process.rs
+++ b/src/bms/process.rs
@@ -12,13 +12,13 @@ use strict_num_extended::{FinF64, PositiveF64};
 use crate::bms::command::string_value::StringValue;
 use crate::bms::parse::check_playing::PlayingError;
 use crate::bms::prelude::*;
-use crate::chart::event::{ChartEvent, FlowEvent, PlayheadEvent};
+use crate::chart::event::{BmsEvent, ChartEvent, FlowEvent, PlayheadEvent};
+use crate::chart::prelude::{TimeSpan, YCoordinate};
 use crate::chart::process::{
     AllEventsIndex, BmpId, ChartEventIdGenerator, ChartResources, Process, WavId,
+    calculate_cumulative_times,
 };
-use crate::chart::{
-    Chart, DEFAULT_BPM, DEFAULT_SPEED, MAX_FIN_F64, MAX_NON_NEGATIVE_F64, TimeSpan, YCoordinate,
-};
+use crate::chart::{Chart, DEFAULT_BPM, DEFAULT_SPEED, MAX_FIN_F64, MAX_NON_NEGATIVE_F64};
 use strict_num_extended::NonNegativeF64;
 
 /// BMS format parser.
@@ -544,10 +544,10 @@ impl AllEventsIndex {
         for (layer, opacity_changes) in &bms.bmp.bga_opacity_changes {
             for opacity_obj in opacity_changes.values() {
                 let y = get_event_y(opacity_obj.time);
-                let event = ChartEvent::BgaOpacityChange {
+                let event = ChartEvent::Bms(BmsEvent::BgaOpacityChange {
                     layer: *layer,
                     opacity: opacity_obj.opacity,
-                };
+                });
                 events_map.entry(y).or_default().push(PlayheadEvent::new(
                     id_gen.next_id(),
                     y,
@@ -561,10 +561,10 @@ impl AllEventsIndex {
         for (layer, argb_changes) in &bms.bmp.bga_argb_changes {
             for argb_obj in argb_changes.values() {
                 let y = get_event_y(argb_obj.time);
-                let event = ChartEvent::BgaArgbChange {
+                let event = ChartEvent::Bms(BmsEvent::BgaArgbChange {
                     layer: *layer,
                     argb: argb_obj.argb,
-                };
+                });
                 events_map.entry(y).or_default().push(PlayheadEvent::new(
                     id_gen.next_id(),
                     y,
@@ -577,9 +577,9 @@ impl AllEventsIndex {
         // BGM volume change events
         for bgm_volume_obj in bms.volume.bgm_volume_changes.values() {
             let y = get_event_y(bgm_volume_obj.time);
-            let event = ChartEvent::BgmVolumeChange {
+            let event = ChartEvent::Bms(BmsEvent::BgmVolumeChange {
                 volume: bgm_volume_obj.volume,
-            };
+            });
             events_map.entry(y).or_default().push(PlayheadEvent::new(
                 id_gen.next_id(),
                 y,
@@ -591,9 +591,9 @@ impl AllEventsIndex {
         // KEY volume change events
         for key_volume_obj in bms.volume.key_volume_changes.values() {
             let y = get_event_y(key_volume_obj.time);
-            let event = ChartEvent::KeyVolumeChange {
+            let event = ChartEvent::Bms(BmsEvent::KeyVolumeChange {
                 volume: key_volume_obj.volume,
-            };
+            });
             events_map.entry(y).or_default().push(PlayheadEvent::new(
                 id_gen.next_id(),
                 y,
@@ -605,9 +605,9 @@ impl AllEventsIndex {
         // Text display events
         for text_obj in bms.text.text_events.values() {
             let y = get_event_y(text_obj.time);
-            let event = ChartEvent::TextDisplay {
+            let event = ChartEvent::Bms(BmsEvent::TextDisplay {
                 text: text_obj.text.clone(),
-            };
+            });
             events_map.entry(y).or_default().push(PlayheadEvent::new(
                 id_gen.next_id(),
                 y,
@@ -619,9 +619,9 @@ impl AllEventsIndex {
         // Judge level change events
         for judge_obj in bms.judge.judge_events.values() {
             let y = get_event_y(judge_obj.time);
-            let event = ChartEvent::JudgeLevelChange {
+            let event = ChartEvent::Bms(BmsEvent::JudgeLevelChange {
                 level: judge_obj.judge_level,
-            };
+            });
             events_map.entry(y).or_default().push(PlayheadEvent::new(
                 id_gen.next_id(),
                 y,
@@ -632,9 +632,9 @@ impl AllEventsIndex {
 
         for seek_obj in bms.video.seek_events.values() {
             let y = get_event_y(seek_obj.time);
-            let event = ChartEvent::VideoSeek {
-                seek_time: seek_obj.position.to_string().parse::<f64>().unwrap_or(0.0),
-            };
+            let event = ChartEvent::Bms(BmsEvent::VideoSeek {
+                seek_time: seek_obj.position.as_f64(),
+            });
             events_map.entry(y).or_default().push(PlayheadEvent::new(
                 id_gen.next_id(),
                 y,
@@ -645,9 +645,9 @@ impl AllEventsIndex {
 
         for bga_keybound_obj in bms.bmp.bga_keybound_events.values() {
             let y = get_event_y(bga_keybound_obj.time);
-            let event = ChartEvent::BgaKeybound {
+            let event = ChartEvent::Bms(BmsEvent::BgaKeybound {
                 event: bga_keybound_obj.event.clone(),
-            };
+            });
             events_map.entry(y).or_default().push(PlayheadEvent::new(
                 id_gen.next_id(),
                 y,
@@ -658,9 +658,9 @@ impl AllEventsIndex {
 
         for option_obj in bms.option.option_events.values() {
             let y = get_event_y(option_obj.time);
-            let event = ChartEvent::OptionChange {
+            let event = ChartEvent::Bms(BmsEvent::OptionChange {
                 option: option_obj.option.clone(),
-            };
+            });
             events_map.entry(y).or_default().push(PlayheadEvent::new(
                 id_gen.next_id(),
                 y,
@@ -727,8 +727,7 @@ pub fn precompute_activate_times(
         .sorted_by_key(|(y, _)| *y)
         .collect();
 
-    let cum_map =
-        super::calculate_cumulative_times(&points, init_bpm_value, &bpm_changes, &stop_list);
+    let cum_map = calculate_cumulative_times(&points, init_bpm_value, &bpm_changes, &stop_list);
 
     let new_map: std::collections::BTreeMap<YCoordinate, Vec<PlayheadEvent>> = all_events
         .as_by_y()
@@ -814,6 +813,52 @@ impl Process for Bms {
 
     fn process(self) -> Result<Chart, Self::Error> {
         BmsProcessor::parse::<crate::bms::command::channel::mapper::KeyLayoutBeat>(&self)
+    }
+}
+
+// ---- BaseBpmGenerator implementations for BMS ----
+
+use crate::chart::player::base_bpm::{
+    BaseBpm, BaseBpmGenerator, MaxBpmGenerator, MinBpmGenerator, StartBpmGenerator,
+};
+
+impl BaseBpmGenerator<Bms> for StartBpmGenerator {
+    fn generate(&self, bms: &Bms) -> Option<BaseBpm> {
+        bms.bpm
+            .bpm
+            .as_ref()
+            .and_then(|bpm| bpm.value().as_ref().ok().copied())
+            .map(BaseBpm::new)
+    }
+}
+
+impl BaseBpmGenerator<Bms> for MinBpmGenerator {
+    fn generate(&self, bms: &Bms) -> Option<BaseBpm> {
+        bms.bpm
+            .bpm
+            .iter()
+            .filter_map(|bpm| bpm.value().as_ref().ok().copied())
+            .chain(bms.bpm.bpm_changes.values().map(|change| change.bpm))
+            .min()
+            .map(BaseBpm::new)
+    }
+}
+
+impl BaseBpmGenerator<Bms> for MaxBpmGenerator {
+    fn generate(&self, bms: &Bms) -> Option<BaseBpm> {
+        bms.bpm
+            .bpm
+            .iter()
+            .filter_map(|bpm| bpm.value().as_ref().ok().copied())
+            .chain(bms.bpm.bpm_changes.values().map(|change| change.bpm))
+            .max()
+            .map(BaseBpm::new)
+    }
+}
+
+impl BaseBpmGenerator<Bms> for crate::chart::player::base_bpm::ManualBpmGenerator {
+    fn generate(&self, _bms: &Bms) -> Option<BaseBpm> {
+        Some(self.0)
     }
 }
 

--- a/src/bms/unparse.rs
+++ b/src/bms/unparse.rs
@@ -5,7 +5,10 @@ use std::collections::{BTreeMap, HashMap};
 
 use num::Integer;
 
-use crate::bms::prelude::*;
+use crate::{
+    bms::prelude::*,
+    chart::types::{Argb, BgaLayer},
+};
 
 impl Bms {
     /// Convert Bms to `Vec<Token>` (in conventional order: header -> definitions -> resources -> messages).

--- a/src/bmson.rs
+++ b/src/bmson.rs
@@ -31,6 +31,7 @@ pub mod bms_to_bmson;
 pub mod bmson_to_bms;
 pub mod parse;
 pub mod prelude;
+pub mod process;
 pub mod pulse;
 
 use std::{

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -14,6 +14,7 @@ use crate::{
         BarLine, Bga, BgaEvent, BgaHeader, BgaId, Bmson, BmsonInfo, BpmEvent, KeyChannel, KeyEvent,
         MineChannel, MineEvent, Note, ScrollEvent, SoundChannel, StopEvent, pulse::PulseConverter,
     },
+    chart::types::BgaLayer,
 };
 
 use strict_num_extended::{FinF64, NonNegativeF64, PositiveF64};

--- a/src/bmson/bmson_to_bms.rs
+++ b/src/bmson/bmson_to_bms.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use crate::{
     bms::{command::string_value::StringValue, prelude::*},
     bmson::{BgaId, Bmson, pulse::PulseNumber},
+    chart::types::{Argb, BgaLayer},
 };
 
 /// Warnings that occur during conversion from `Bmson` to `Bms`.

--- a/src/bmson/prelude.rs
+++ b/src/bmson/prelude.rs
@@ -31,3 +31,6 @@ pub use super::{default_mode_hint, default_percentage, default_resolution};
 
 // Re-export BMS types that are dependencies of BMSON types
 pub use crate::bms::command::LnMode;
+
+// Re-export process module
+pub use super::process::BmsonProcessor;

--- a/src/bmson/process.rs
+++ b/src/bmson/process.rs
@@ -10,15 +10,15 @@ use std::{
 use itertools::Itertools;
 use strict_num_extended::{FinF64, NonNegativeF64, PositiveF64};
 
-use crate::bms::prelude::{BgaLayer, Key, NoteKind, PlayerSide};
 use crate::bmson::prelude::*;
 use crate::chart::event::{ChartEvent, FlowEvent, PlayheadEvent};
+use crate::chart::prelude::{TimeSpan, YCoordinate};
 use crate::chart::process::{
     AllEventsIndex, BmpId, ChartEventIdGenerator, ChartResources, Process, WavId,
+    calculate_cumulative_times,
 };
-use crate::chart::{
-    Chart, DEFAULT_SPEED, MAX_FIN_F64, MAX_NON_NEGATIVE_F64, TimeSpan, YCoordinate,
-};
+use crate::chart::types::{BgaLayer, Key, NoteKind, PlayerSide};
+use crate::chart::{Chart, DEFAULT_SPEED, MAX_FIN_F64, MAX_NON_NEGATIVE_F64};
 use crate::util::StrExtension;
 
 /// BMSON format parser.
@@ -250,8 +250,7 @@ impl AllEventsIndex {
             .sorted_by(|a, b| a.0.cmp(&b.0))
             .collect();
 
-        let cum_map =
-            super::calculate_cumulative_times(&points, init_bpm, &bpm_changes, &stop_list);
+        let cum_map = calculate_cumulative_times(&points, init_bpm, &bpm_changes, &stop_list);
         let mut events_map: BTreeMap<YCoordinate, Vec<PlayheadEvent>> = BTreeMap::new();
         let to_time_span =
             |secs: f64| TimeSpan::from_duration(std::time::Duration::from_secs_f64(secs));
@@ -449,5 +448,41 @@ impl Process for Bmson<'_> {
 
     fn process(self) -> Result<Chart, Self::Error> {
         Ok(BmsonProcessor::parse(&self))
+    }
+}
+
+// ---- BaseBpmGenerator implementations for BMSON ----
+
+use crate::chart::player::base_bpm::{
+    BaseBpm, BaseBpmGenerator, MaxBpmGenerator, MinBpmGenerator, StartBpmGenerator,
+};
+
+impl<'a> BaseBpmGenerator<Bmson<'a>> for StartBpmGenerator {
+    fn generate(&self, bmson: &Bmson<'a>) -> Option<BaseBpm> {
+        Some(BaseBpm::new(bmson.info.init_bpm))
+    }
+}
+
+impl<'a> BaseBpmGenerator<Bmson<'a>> for MinBpmGenerator {
+    fn generate(&self, bmson: &Bmson<'a>) -> Option<BaseBpm> {
+        std::iter::once(bmson.info.init_bpm)
+            .chain(bmson.bpm_events.iter().map(|ev| ev.bpm))
+            .min()
+            .map(BaseBpm::new)
+    }
+}
+
+impl<'a> BaseBpmGenerator<Bmson<'a>> for MaxBpmGenerator {
+    fn generate(&self, bmson: &Bmson<'a>) -> Option<BaseBpm> {
+        std::iter::once(bmson.info.init_bpm)
+            .chain(bmson.bpm_events.iter().map(|ev| ev.bpm))
+            .max()
+            .map(BaseBpm::new)
+    }
+}
+
+impl<'a> BaseBpmGenerator<Bmson<'a>> for crate::chart::player::base_bpm::ManualBpmGenerator {
+    fn generate(&self, _bmson: &Bmson<'a>) -> Option<BaseBpm> {
+        Some(self.0)
     }
 }

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -70,6 +70,8 @@ pub mod prelude;
 
 pub mod process;
 
+pub mod types;
+
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 

--- a/src/chart/event.rs
+++ b/src/chart/event.rs
@@ -1,8 +1,7 @@
 //! Chart event types
 
-use crate::bms::prelude::SwBgaEvent;
-use crate::bms::prelude::{Argb, BgaLayer, Key, NoteKind, PlayerSide};
 use crate::chart::process::{BmpId, ChartEventId, WavId};
+use crate::chart::types::{Argb, BgaLayer, Key, NoteKind, PlayerSide};
 use gametime::TimeSpan;
 use strict_num_extended::FinF64;
 use strict_num_extended::NonNegativeF64;
@@ -109,6 +108,61 @@ impl std::ops::Div<FinF64> for YCoordinate {
     }
 }
 
+/// BMS-specific events enum.
+/// Contains all BMS-specific events that don't apply to BMSON.
+#[derive(Debug, Clone)]
+pub enum BmsEvent {
+    /// BGA opacity change event.
+    BgaOpacityChange {
+        /// Target BGA layer.
+        layer: BgaLayer,
+        /// Opacity value (0-255).
+        opacity: u8,
+    },
+    /// BGA ARGB color change event.
+    BgaArgbChange {
+        /// Target BGA layer.
+        layer: BgaLayer,
+        /// ARGB color value.
+        argb: Argb,
+    },
+    /// BGM volume change event.
+    BgmVolumeChange {
+        /// Volume value (0-255).
+        volume: u8,
+    },
+    /// Key volume change event.
+    KeyVolumeChange {
+        /// Volume value (0-255).
+        volume: u8,
+    },
+    /// Text display event.
+    TextDisplay {
+        /// Display text content.
+        text: String,
+    },
+    /// Judge level change event.
+    JudgeLevelChange {
+        /// New judge level.
+        level: crate::bms::command::JudgeLevel,
+    },
+    /// Video seek event.
+    VideoSeek {
+        /// Seek time point (seconds)
+        seek_time: f64,
+    },
+    /// BGA key binding event.
+    BgaKeybound {
+        /// BGA event to bind.
+        event: crate::bms::command::minor_command::SwBgaEvent,
+    },
+    /// Option change event.
+    OptionChange {
+        /// Option name.
+        option: String,
+    },
+}
+
 /// Events generated during playback (Elm style).
 ///
 /// These events represent actual events during chart playback, such as note triggers, BGM playback,
@@ -168,73 +222,8 @@ pub enum ChartEvent {
         /// BGA/BMP resource ID, get the corresponding file path through the `bmp_files()` method (if any)
         bmp_id: Option<BmpId>,
     },
-    /// BGA opacity change event (requires minor-command feature)
-    ///
-    /// Dynamically adjust the opacity of the specified BGA layer to achieve fade-in/fade-out effects.
-    BgaOpacityChange {
-        /// BGA layer
-        layer: BgaLayer,
-        /// Opacity value (0x01-0xFF, 0x01 means almost transparent, 0xFF means completely opaque)
-        opacity: u8,
-    },
-    /// BGA ARGB color change event (requires minor-command feature)
-    ///
-    /// Dynamically adjust the color of the specified BGA layer through ARGB values to achieve color filter effects.
-    BgaArgbChange {
-        /// BGA layer
-        layer: BgaLayer,
-        /// ARGB color value (format: 0xAARRGGBB)
-        argb: Argb,
-    },
-    /// BGM volume change event
-    ///
-    /// Triggered when playback position reaches BGM volume change time point, used to adjust background music volume.
-    BgmVolumeChange {
-        /// Volume value (0x01-0xFF, 0x01 means minimum volume, 0xFF means maximum volume)
-        volume: u8,
-    },
-    /// KEY volume change event
-    ///
-    /// Triggered when playback position reaches KEY volume change time point, used to adjust key sound effect volume.
-    KeyVolumeChange {
-        /// Volume value (0x01-0xFF, 0x01 means minimum volume, 0xFF means maximum volume)
-        volume: u8,
-    },
-    /// Text display event
-    ///
-    /// Triggered when playback position reaches text display time point, used to display text information in the chart.
-    TextDisplay {
-        /// Text content to display
-        text: String,
-    },
-    /// Judge level change event
-    ///
-    /// Triggered when playback position reaches judge level change time point, used to adjust the strictness of the judgment window.
-    JudgeLevelChange {
-        /// Judge level (`VeryHard`, Hard, Normal, Easy, `OtherInt`)
-        level: crate::bms::command::JudgeLevel,
-    },
-    /// Video seek event (requires minor-command feature)
-    ///
-    /// Triggered when playback position reaches video seek time point, used for video playback control.
-    VideoSeek {
-        /// Seek time point (seconds)
-        seek_time: f64,
-    },
-    /// BGA key binding event (requires minor-command feature)
-    ///
-    /// Triggered when playback position reaches BGA key binding time point, used for BGA and key binding control.
-    BgaKeybound {
-        /// BGA key binding event type
-        event: SwBgaEvent,
-    },
-    /// Option change event (requires minor-command feature)
-    ///
-    /// Triggered when playback position reaches option change time point, used for dynamic game option adjustment.
-    OptionChange {
-        /// Option content
-        option: String,
-    },
+    /// BMS-specific event (BMS only, not applicable to BMSON)
+    Bms(BmsEvent),
     /// Measure line event
     ///
     /// Triggered when playback position reaches measure line position, used for chart structure display.
@@ -242,7 +231,6 @@ pub enum ChartEvent {
 }
 
 /// Timeline event and position wrapper type.
-///
 /// Represents an event in chart playback and its position on the timeline.
 #[derive(Debug, Clone)]
 pub struct PlayheadEvent {

--- a/src/chart/player/base_bpm.rs
+++ b/src/chart/player/base_bpm.rs
@@ -1,8 +1,5 @@
 //! Module for base BPM generation strategies and types.
 
-use crate::bms::prelude::Bms;
-#[cfg(feature = "bmson")]
-use crate::bmson::prelude::Bmson;
 use strict_num_extended::PositiveF64;
 
 /// Base BPM wrapper type.
@@ -126,81 +123,5 @@ impl ManualBpmGenerator {
     #[must_use]
     pub const fn into_value(self) -> BaseBpm {
         self.0
-    }
-}
-
-// ---- Generators for BMS ----
-impl BaseBpmGenerator<Bms> for StartBpmGenerator {
-    fn generate(&self, bms: &Bms) -> Option<BaseBpm> {
-        bms.bpm
-            .bpm
-            .as_ref()
-            .and_then(|bpm| bpm.value().as_ref().ok().copied())
-            .map(BaseBpm::new)
-    }
-}
-
-impl BaseBpmGenerator<Bms> for MinBpmGenerator {
-    fn generate(&self, bms: &Bms) -> Option<BaseBpm> {
-        bms.bpm
-            .bpm
-            .iter()
-            .filter_map(|bpm| bpm.value().as_ref().ok().copied())
-            .chain(bms.bpm.bpm_changes.values().map(|change| change.bpm))
-            .min()
-            .map(BaseBpm::new)
-    }
-}
-
-impl BaseBpmGenerator<Bms> for MaxBpmGenerator {
-    fn generate(&self, bms: &Bms) -> Option<BaseBpm> {
-        bms.bpm
-            .bpm
-            .iter()
-            .filter_map(|bpm| bpm.value().as_ref().ok().copied())
-            .chain(bms.bpm.bpm_changes.values().map(|change| change.bpm))
-            .max()
-            .map(BaseBpm::new)
-    }
-}
-
-impl BaseBpmGenerator<Bms> for ManualBpmGenerator {
-    fn generate(&self, _bms: &Bms) -> Option<BaseBpm> {
-        Some(self.0)
-    }
-}
-
-// ---- Generators for BMSON ----
-#[cfg(feature = "bmson")]
-impl<'a> BaseBpmGenerator<Bmson<'a>> for StartBpmGenerator {
-    fn generate(&self, bmson: &Bmson<'a>) -> Option<BaseBpm> {
-        Some(BaseBpm::new(bmson.info.init_bpm))
-    }
-}
-
-#[cfg(feature = "bmson")]
-impl<'a> BaseBpmGenerator<Bmson<'a>> for MinBpmGenerator {
-    fn generate(&self, bmson: &Bmson<'a>) -> Option<BaseBpm> {
-        std::iter::once(bmson.info.init_bpm)
-            .chain(bmson.bpm_events.iter().map(|ev| ev.bpm))
-            .min()
-            .map(BaseBpm::new)
-    }
-}
-
-#[cfg(feature = "bmson")]
-impl<'a> BaseBpmGenerator<Bmson<'a>> for MaxBpmGenerator {
-    fn generate(&self, bmson: &Bmson<'a>) -> Option<BaseBpm> {
-        std::iter::once(bmson.info.init_bpm)
-            .chain(bmson.bpm_events.iter().map(|ev| ev.bpm))
-            .max()
-            .map(BaseBpm::new)
-    }
-}
-
-#[cfg(feature = "bmson")]
-impl<'a> BaseBpmGenerator<Bmson<'a>> for ManualBpmGenerator {
-    fn generate(&self, _bmson: &Bmson<'a>) -> Option<BaseBpm> {
-        Some(self.0)
     }
 }

--- a/src/chart/prelude.rs
+++ b/src/chart/prelude.rs
@@ -21,19 +21,11 @@ pub use gametime::TimeSpan;
 pub use strict_num_extended::NonNegativeF64;
 
 // Re-export event types
+pub use super::event::BmsEvent;
 pub use super::event::{ChartEvent, PlayheadEvent};
 
-// Re-export common types from bms module
-pub use crate::bms::prelude::{BgaLayer, Key, NoteKind, PlayerSide};
-
-pub use crate::bms::prelude::SwBgaEvent;
-
-// Re-export BmsProcessor from bms module
-pub use super::process::bms::BmsProcessor;
-
-// Re-export BmsonProcessor from bmson module
-#[cfg(feature = "bmson")]
-pub use super::process::bmson::BmsonProcessor;
+// Re-export chart types
+pub use crate::chart::types::{Key, NoteKind, PlayerSide};
 
 // Re-export ChartPlayer
 pub use super::player::{ChartPlayer, PlaybackState};

--- a/src/chart/process.rs
+++ b/src/chart/process.rs
@@ -5,14 +5,11 @@ use std::collections::{BTreeMap, HashMap};
 use std::ops::{Bound, Range, RangeBounds};
 use std::path::PathBuf;
 
-use crate::bms::command::channel::NoteKind;
 use crate::chart::event::{ChartEvent, PlayheadEvent, YCoordinate};
+use crate::chart::types::NoteKind;
 use crate::chart::{Chart, TimeSpan};
 use strict_num_extended::NonNegativeF64;
 use strict_num_extended::PositiveF64;
-
-pub mod bms;
-pub mod bmson;
 
 /// Trait for types that can be processed into a `Chart`. It's intended that chart types implement this.
 pub trait Process {
@@ -624,9 +621,9 @@ mod tests {
 
     use super::AllEventsIndex;
     use super::ChartEventId;
-    use crate::bms::command::channel::{Key, NoteKind, PlayerSide};
     use crate::chart::TimeSpan;
     use crate::chart::event::{ChartEvent, PlayheadEvent, YCoordinate};
+    use crate::chart::types::{Key, NoteKind, PlayerSide};
     use strict_num_extended::NonNegativeF64;
 
     // Test constants

--- a/src/chart/types.rs
+++ b/src/chart/types.rs
@@ -1,0 +1,161 @@
+//! Chart-level types for describing notes and player interactions.
+//!
+//! These types describe fundamental concepts used in charts,
+//! independent of any specific file format (BMS, BMSON, etc.).
+
+/// A kind of the note.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum NoteKind {
+    /// A normal note can be seen by the user.
+    Visible,
+    /// A invisible note cannot be played by the user.
+    Invisible,
+    /// A long-press note (LN), requires the user to hold pressing the key.
+    Long,
+    /// A landmine note that treated as POOR judgement when
+    Landmine,
+}
+
+impl NoteKind {
+    /// Returns whether the note is a displayable.
+    #[must_use]
+    pub const fn is_displayable(self) -> bool {
+        !matches!(self, Self::Invisible)
+    }
+
+    /// Returns whether the note is a playable.
+    #[must_use]
+    pub const fn is_playable(self) -> bool {
+        matches!(self, Self::Visible | Self::Long)
+    }
+
+    /// Returns whether the note is a long-press note.
+    #[must_use]
+    pub const fn is_long(self) -> bool {
+        matches!(self, Self::Long)
+    }
+}
+
+/// A side of the player.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum PlayerSide {
+    /// The player 1 side.
+    #[default]
+    Player1,
+    /// The player 2 side.
+    Player2,
+}
+
+/// A key of the controller or keyboard.
+///
+/// - Beat 5K/7K/10K/14K:
+/// ```text
+/// |---------|----------------------|
+/// |         |   [K2]  [K4]  [K6]   |
+/// |(Scratch)|[K1]  [K3]  [K5]  [K7]|
+/// |---------|----------------------|
+/// ```
+///
+/// - PMS:
+/// ```text
+/// |----------------------------|
+/// |   [K2]  [K4]  [K6]  [K8]   |
+/// |[K1]  [K3]  [K5]  [K7]  [K9]|
+/// |----------------------------|
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum Key {
+    /// The keys for the controller.
+    Key(u8),
+    /// The scratch disk.
+    Scratch(u8),
+    /// The foot pedal.
+    FootPedal,
+    /// The zone that the user can scratch disk freely.
+    /// `17` in BMS-type Player1.
+    FreeZone,
+}
+
+impl Key {
+    /// Returns whether the key expected a piano keyboard.
+    #[must_use]
+    pub const fn is_keyxx(&self) -> bool {
+        matches!(self, Self::Key(_))
+    }
+
+    /// Returns the key number if it's a Key variant.
+    #[must_use]
+    pub const fn key_number(&self) -> Option<u8> {
+        if let Self::Key(n) = self {
+            Some(*n)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the scratch number if it's a Scratch variant.
+    #[must_use]
+    pub const fn scratch_number(&self) -> Option<u8> {
+        if let Self::Scratch(n) = self {
+            Some(*n)
+        } else {
+            None
+        }
+    }
+
+    /// Creates a Key variant with the given number.
+    #[must_use]
+    pub const fn new_key(n: u8) -> Self {
+        Self::Key(n)
+    }
+
+    /// Creates a Scratch variant with the given number.
+    #[must_use]
+    pub const fn new_scratch(n: u8) -> Self {
+        Self::Scratch(n)
+    }
+}
+
+/// BGA layer type (shared between BMS and BMSON).
+/// Order matches existing `BmsLayer` definition: Base, Poor, Overlay, Overlay2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum BgaLayer {
+    /// The lowest layer.
+    Base,
+    /// Layer which is displayed only if a player missed to play notes.
+    Poor,
+    /// An overlaying layer.
+    Overlay,
+    /// An overlaying layer layered over `Overlay`.
+    Overlay2,
+}
+
+/// ARGB color type (shared between BMS and BMSON).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Argb {
+    /// Alpha component.
+    pub alpha: u8,
+    /// Red component.
+    pub red: u8,
+    /// Green component.
+    pub green: u8,
+    /// Blue component.
+    pub blue: u8,
+}
+
+impl Default for Argb {
+    fn default() -> Self {
+        Self {
+            alpha: 255,
+            red: 0,
+            green: 0,
+            blue: 0,
+        }
+    }
+}

--- a/tests/chart/bmson/activate_time.rs
+++ b/tests/chart/bmson/activate_time.rs
@@ -3,6 +3,7 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
+use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 
 use super::assert_time_close;

--- a/tests/chart/bmson/chart.rs
+++ b/tests/chart/bmson/chart.rs
@@ -3,6 +3,7 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
+use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 
 fn assert_playback_state_equal(state1: &PlaybackState, state2: &PlaybackState) {

--- a/tests/chart/bmson/continue_time.rs
+++ b/tests/chart/bmson/continue_time.rs
@@ -3,6 +3,7 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
+use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 
 use super::{MICROSECOND_EPSILON, assert_time_close};

--- a/tests/chart/bmson/playback_state.rs
+++ b/tests/chart/bmson/playback_state.rs
@@ -3,6 +3,7 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
+use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 use strict_num_extended::{FinF64, PositiveF64};
 

--- a/tests/chart/bmson/visible_events.rs
+++ b/tests/chart/bmson/visible_events.rs
@@ -3,6 +3,7 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
+use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 use strict_num_extended::{FinF64, PositiveF64};
 


### PR DESCRIPTION
- Relocate chart types (Key, NoteKind, PlayerSide, Argb, BgaLayer) to chart/types.rs
- Move processor modules from chart/process/{bms,bmson}.rs to {bms,bmson}/process.rs
- Wrap BMS-specific ChartEvent variants in BmsEvent enum
- Move BaseBpmGenerator impls to respective processor modules