### PR TITLE
refactor: remove generic key mapper from BMS API

### DIFF
--- a/benches/parse_bms.rs
+++ b/benches/parse_bms.rs
@@ -1,6 +1,7 @@
 //! Benchmark for `BMS` file parsing and chart conversion.
 
-use bms_rs::bms::{default_config, parse_bms, process::BmsProcessor};
+use bms_rs::bms::{default_config, parse_bms};
+use bms_rs::chart::process::Process;
 use criterion::{Criterion, Throughput};
 use std::{collections::BTreeMap, sync::LazyLock};
 
@@ -77,11 +78,7 @@ fn bench_bms_to_chart(c: &mut Criterion) {
 
     for (name, chart) in PARSED_CHARTS.iter() {
         group.bench_function(name, |b| {
-            b.iter(|| {
-                BmsProcessor::parse::<bms_rs::bms::command::channel::mapper::KeyLayoutBeat>(
-                    std::hint::black_box(chart),
-                )
-            });
+            b.iter(|| std::hint::black_box(chart).process());
         });
     }
 

--- a/benches/parse_bmson.rs
+++ b/benches/parse_bmson.rs
@@ -1,6 +1,7 @@
 //! Benchmark for `BMSON` file parsing and chart conversion.
 
-use bms_rs::bmson::{Bmson, parse_bmson, process::BmsonProcessor};
+use bms_rs::bmson::{Bmson, parse_bmson};
+use bms_rs::chart::process::Process;
 use criterion::{Criterion, Throughput};
 use std::{collections::BTreeMap, sync::LazyLock};
 
@@ -74,7 +75,7 @@ fn bench_bmson_to_chart(c: &mut Criterion) {
 
     for (name, chart) in PARSED_CHARTS.iter() {
         group.bench_function(name, |b| {
-            b.iter(|| BmsonProcessor::parse(std::hint::black_box(chart)));
+            b.iter(|| std::hint::black_box(chart).process());
         });
     }
 

--- a/examples/comprehensive_diagnostics.rs
+++ b/examples/comprehensive_diagnostics.rs
@@ -9,37 +9,13 @@ use bms_rs::bms::prelude::*;
 fn main() {
     println!("=== BMS-RS Diagnostics Functionality Demo ===\n");
 
-    // Demonstrate usage of all XXXWarningWithRange types
-    demonstrate_warning_types();
+    // Note: PlayingWarning/PlayingError are no longer part of BmsWarning.
+    // They remain available through Bms::check_playing for direct use.
 
     println!("\n=== Integration Usage Example ===\n");
 
     // Demonstrate complete integration workflow
     demonstrate_integration();
-}
-
-fn demonstrate_warning_types() {
-    println!("1. Demonstrate ToAriadne implementation for all warning types:");
-
-    let source_text = "#TITLE Demo\n#ARTIST Composer\n";
-    let source = SimpleSource::new("demo.bms", source_text);
-
-    // Create various types of warnings
-    let warnings = [
-        BmsWarning::PlayingWarning(PlayingWarning::TotalUndefined),
-        BmsWarning::PlayingWarning(PlayingWarning::NoDisplayableNotes),
-        BmsWarning::PlayingWarning(PlayingWarning::NoPlayableNotes),
-    ];
-
-    println!("   Created {} warnings", warnings.len());
-
-    for (i, warning) in warnings.iter().enumerate() {
-        println!("   Warning {}: {}", i + 1, warning);
-
-        // Demonstrate ToAriadne trait usage
-        let _report = warning.to_report(&source);
-        println!("   -> Successfully converted to ariadne Report");
-    }
 }
 
 fn demonstrate_integration() {

--- a/examples/microquad_player.rs
+++ b/examples/microquad_player.rs
@@ -8,7 +8,6 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use bms_rs::bms::prelude::*;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 use clap::Parser;
 use gametime::{TimeSpan, TimeStamp};
@@ -216,8 +215,9 @@ fn load_chart(path: &Path) -> Result<(Chart, BaseBpm), String> {
                 .generate(&bms)
                 .unwrap_or(BaseBpm::new(DEFAULT_BPM));
 
-            // Use KeyLayoutBeat mapper (supports 7+1k)
-            let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms)
+            // Process Bms into Chart
+            let chart = bms
+                .process()
                 .map_err(|e| format!("Failed to parse chart: {e}"))?;
             (chart, base_bpm)
         }
@@ -225,7 +225,7 @@ fn load_chart(path: &Path) -> Result<(Chart, BaseBpm), String> {
             // BMSON format
             #[cfg(feature = "bmson")]
             {
-                let bmson =
+                let bmson: bms_rs::bmson::Bmson<'_> =
                     serde_json::from_str(&content).map_err(|e| format!("JSON parse error: {e}"))?;
 
                 // First generate base BPM from BMSON
@@ -233,7 +233,7 @@ fn load_chart(path: &Path) -> Result<(Chart, BaseBpm), String> {
                     .generate(&bmson)
                     .unwrap_or(BaseBpm::new(DEFAULT_BPM));
 
-                let chart = BmsonProcessor::parse(&bmson);
+                let chart = bmson.process().expect("BMSON processing should succeed");
                 (chart, base_bpm)
             }
             #[cfg(not(feature = "bmson"))]

--- a/src/bms.rs
+++ b/src/bms.rs
@@ -15,7 +15,7 @@
 //! - Do not support commands having ambiguous semantics.
 //! - Do not support syntax came from typo (such as `#RONDOM` or `#END IF`).
 
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 pub mod command;
 
@@ -40,7 +40,6 @@ use self::{
     model::Bms,
     parse::{
         ParseErrorWithRange, ParseWarningWithRange,
-        check_playing::{PlayingCheckOutput, PlayingError, PlayingWarning},
         token_processor::{
             DefaultTokenRelaxer, NoopTokenModifier, SequentialTokenModifier, TokenModifier,
             TokenProcessor, full_preset,
@@ -60,172 +59,133 @@ pub enum BmsWarning {
     /// An error comes from syntax parser.
     #[error("Warn: parse: {0}")]
     Parse(#[from] ParseWarningWithRange),
-    /// A warning for playing.
-    #[error("Warn: playing: {0}")]
-    PlayingWarning(#[from] PlayingWarning),
-    /// An error for playing.
-    #[error("Error: playing: {0}")]
-    PlayingError(#[from] PlayingError),
 }
 
 /// A configuration builder for [`parse_bms`]. Its methods can be chained to set parameters you want.
 #[must_use]
-pub struct ParseConfig<T, P, R, M> {
-    key_mapper: PhantomData<fn() -> T>,
+pub struct ParseConfig<P, R, M> {
     prompter: P,
     rng: R,
     token_modifier: M,
 }
 
-/// Creates the default configuration builder with the basic key layout [`KeyLayoutBeat`], the prompter [`AlwaysWarnAndUseNewer`] and the standard RNG [`rand::rngs::StdRng`].
+/// Creates the default configuration builder with the basic key layout [`BmsLayoutBeat`], the prompter [`AlwaysWarnAndUseNewer`] and the standard RNG [`rand::rngs::StdRng`].
 #[cfg(feature = "rand")]
-pub fn default_config() -> ParseConfig<
-    KeyLayoutBeat,
-    AlwaysWarnAndUseNewer,
-    RandRng<rand::rngs::StdRng>,
-    DefaultTokenRelaxer,
-> {
+pub fn default_config()
+-> ParseConfig<AlwaysWarnAndUseNewer, RandRng<rand::rngs::StdRng>, DefaultTokenRelaxer> {
     ParseConfig {
-        key_mapper: PhantomData,
         prompter: AlwaysWarnAndUseNewer,
         rng: RandRng(rand::make_rng()),
         token_modifier: DefaultTokenRelaxer,
     }
 }
 
-/// Creates the default configuration builder with the basic key layout [`KeyLayoutBeat`], the prompter [`AlwaysWarnAndUseNewer`] and the Java-compatible RNG.
+/// Creates the default configuration builder with the basic key layout [`BmsLayoutBeat`], the prompter [`AlwaysWarnAndUseNewer`] and the Java-compatible RNG.
 /// This version is available when the `rand` feature is not enabled.
 #[cfg(not(feature = "rand"))]
-pub fn default_config()
--> ParseConfig<KeyLayoutBeat, AlwaysWarnAndUseNewer, rng::JavaRandom, DefaultTokenRelaxer> {
+pub fn default_config() -> ParseConfig<AlwaysWarnAndUseNewer, rng::JavaRandom, DefaultTokenRelaxer>
+{
     ParseConfig {
-        key_mapper: PhantomData,
         prompter: AlwaysWarnAndUseNewer,
         rng: rng::JavaRandom::default(),
         token_modifier: DefaultTokenRelaxer,
     }
 }
 
-/// Creates the default configuration builder with the basic key layout [`KeyLayoutBeat`], the prompter [`AlwaysWarnAndUseNewer`] and your RNG.
-pub fn default_config_with_rng<R>(
+/// Creates the default configuration builder with the basic key layout [`BmsLayoutBeat`], the prompter [`AlwaysWarnAndUseNewer`] and your RNG.
+pub const fn default_config_with_rng<R>(
     rng: R,
-) -> ParseConfig<KeyLayoutBeat, AlwaysWarnAndUseNewer, R, DefaultTokenRelaxer> {
+) -> ParseConfig<AlwaysWarnAndUseNewer, R, DefaultTokenRelaxer> {
     ParseConfig {
-        key_mapper: PhantomData,
         prompter: AlwaysWarnAndUseNewer,
         rng,
         token_modifier: DefaultTokenRelaxer,
     }
 }
 
-impl<T, P, R, M> ParseConfig<T, P, R, M> {
-    /// Sets the key mapper to the `T2` one.
-    pub fn key_mapper<T2: KeyLayoutMapper>(self) -> ParseConfig<T2, P, R, M> {
+impl<P, R, M> ParseConfig<P, R, M> {
+    /// Sets a custom prompter for conflict resolution.
+    pub fn prompter<P2: Prompter>(self, prompter: P2) -> ParseConfig<P2, R, M> {
         ParseConfig {
-            key_mapper: PhantomData,
-            prompter: self.prompter,
-            rng: self.rng,
-            token_modifier: self.token_modifier,
-        }
-    }
-
-    /// Sets the prompter to `prompter`.
-    pub fn prompter<P2: Prompter>(self, prompter: P2) -> ParseConfig<T, P2, R, M> {
-        ParseConfig {
-            key_mapper: PhantomData,
             prompter,
             rng: self.rng,
             token_modifier: self.token_modifier,
         }
     }
 
-    /// Sets the RNG to `rng`.
-    pub fn rng<R2: Rng>(self, rng: R2) -> ParseConfig<T, P, R2, M> {
+    /// Sets a custom random number generator.
+    pub fn rng<R2: Rng>(self, rng: R2) -> ParseConfig<P, R2, M> {
         ParseConfig {
-            key_mapper: PhantomData,
             prompter: self.prompter,
             rng,
             token_modifier: self.token_modifier,
         }
     }
 
-    /// Append a token modifier by sequentially composing it after the current one.
-    ///
-    /// This preserves the existing modifier and runs the new modifier afterward, enabling
-    /// static dispatch without heap allocations.
+    /// Appends an additional token modifier after the current one.
     pub fn append_token_modifier<M2: TokenModifier>(
         self,
         token_modifier: M2,
-    ) -> ParseConfig<T, P, R, SequentialTokenModifier<M, M2>>
+    ) -> ParseConfig<P, R, SequentialTokenModifier<M, M2>>
     where
         M: TokenModifier,
     {
         ParseConfig {
-            key_mapper: PhantomData,
             prompter: self.prompter,
             rng: self.rng,
             token_modifier: self.token_modifier.then(token_modifier),
         }
     }
 
-    /// Override and replace the current token modifier with the provided one.
+    /// Replaces the current token modifier with a new one.
     pub fn override_token_modifier<M2: TokenModifier>(
         self,
         token_modifier: M2,
-    ) -> ParseConfig<T, P, R, M2> {
+    ) -> ParseConfig<P, R, M2> {
         ParseConfig {
-            key_mapper: PhantomData,
             prompter: self.prompter,
             rng: self.rng,
             token_modifier,
         }
     }
 
-    /// Map the current token modifier using a closure.
-    ///
-    /// Accepts a closure `f` that takes the current modifier `M` and returns a new
-    /// modifier `M2`. This is useful for wrapping, decorating, or transforming the
-    /// modifier while keeping static dispatch.
-    pub fn map_token_modifier<F, M2>(self, f: F) -> ParseConfig<T, P, R, M2>
+    /// Transforms the token modifier using the provided function.
+    pub fn map_token_modifier<F, M2>(self, f: F) -> ParseConfig<P, R, M2>
     where
         F: FnOnce(M) -> M2,
     {
         ParseConfig {
-            key_mapper: PhantomData,
             prompter: self.prompter,
             rng: self.rng,
             token_modifier: f(self.token_modifier),
         }
     }
 
-    /// Clean all token modifiers by switching to a no-op modifier.
-    pub fn clean_token_modifier(self) -> ParseConfig<T, P, R, NoopTokenModifier> {
+    /// Removes the token modifier, using a no-op modifier instead.
+    pub fn clean_token_modifier(self) -> ParseConfig<P, R, NoopTokenModifier> {
         self.override_token_modifier(NoopTokenModifier)
     }
 
     pub(crate) fn build(self) -> (impl TokenProcessor<Output = Bms>, P)
     where
-        T: KeyLayoutMapper,
         P: Prompter,
         R: Rng,
     {
-        struct AggregateTokenProcessor<T, R> {
-            key_mapper: PhantomData<fn() -> T>,
+        struct AggregateTokenProcessor<R> {
             rng: Rc<RefCell<R>>,
         }
-        impl<T: KeyLayoutMapper, R: Rng> TokenProcessor for AggregateTokenProcessor<T, R> {
+        impl<R: Rng> TokenProcessor for AggregateTokenProcessor<R> {
             type Output = Bms;
 
             fn process<P: Prompter>(
                 &self,
                 ctx: &mut parse::token_processor::ProcessContext<'_, '_, P>,
             ) -> Result<Self::Output, ParseErrorWithRange> {
-                full_preset::<T, R>(Rc::clone(&self.rng)).process(ctx)
+                full_preset::<R>(Rc::clone(&self.rng)).process(ctx)
             }
         }
         (
-            AggregateTokenProcessor::<T, R> {
-                key_mapper: PhantomData,
+            AggregateTokenProcessor::<R> {
                 rng: Rc::new(RefCell::new(self.rng)),
             },
             self.prompter,
@@ -234,42 +194,26 @@ impl<T, P, R, M> ParseConfig<T, P, R, M> {
 }
 
 /// Parse a BMS file from source text with the specified command preset.
-pub fn parse_bms<T: KeyLayoutMapper, P: Prompter, R: Rng, M: TokenModifier>(
+pub fn parse_bms<P: Prompter, R: Rng, M: TokenModifier>(
     source: &str,
-    config: ParseConfig<T, P, R, M>,
+    config: ParseConfig<P, R, M>,
 ) -> BmsOutput {
-    // Parse tokens using default channel parser
     let LexOutput {
         mut tokens,
         lex_warnings,
     } = lex::TokenStream::parse_lex(source);
 
-    // Convert lex warnings to BmsWarning
     let mut warnings: Vec<BmsWarning> = lex_warnings.into_iter().map(BmsWarning::Lex).collect();
 
     config.token_modifier.modify(&mut tokens);
-    let parse_output = Bms::from_token_stream::<'_, T, _, _, _>(&tokens, config);
+    let parse_output = Bms::from_token_stream(&tokens, config);
     let bms_result = parse_output.bms;
-    // Convert parse warnings to BmsWarning
     warnings.extend(
         parse_output
             .parse_warnings
             .into_iter()
             .map(BmsWarning::Parse),
     );
-
-    if let Ok(ref bms) = bms_result {
-        let PlayingCheckOutput {
-            playing_warnings,
-            playing_errors,
-        } = bms.check_playing::<T>();
-
-        // Convert playing warnings to BmsWarning
-        warnings.extend(playing_warnings.into_iter().map(BmsWarning::PlayingWarning));
-
-        // Convert playing errors to BmsWarning
-        warnings.extend(playing_errors.into_iter().map(BmsWarning::PlayingError));
-    }
 
     BmsOutput {
         bms: bms_result,
@@ -294,12 +238,10 @@ impl ToAriadne for BmsWarning {
         &self,
         src: &SimpleSource<'a>,
     ) -> Report<'a, (String, std::ops::Range<usize>)> {
-        use BmsWarning::{Lex, Parse, PlayingError, PlayingWarning};
+        use BmsWarning::{Lex, Parse};
         match self {
             Lex(e) => e.to_report(src),
             Parse(e) => e.to_report(src),
-            PlayingWarning(w) => w.to_report(src),
-            PlayingError(e) => e.to_report(src),
         }
     }
 }

--- a/src/bms/command/channel.rs
+++ b/src/bms/command/channel.rs
@@ -9,7 +9,7 @@ use super::{base62_to_byte, char_to_base62};
 use std::str::FromStr;
 use thiserror::Error;
 
-use self::mapper::KeyLayoutMapper;
+use self::mapper::BmsLayoutMapper;
 
 // Import chart types for use in this module
 use crate::chart::types::{Key, NoteKind, PlayerSide};
@@ -220,10 +220,35 @@ impl NoteChannelId {
         Self([b'0', b'1'])
     }
 
+    /// Check if this is the BGM channel (`01`).
+    #[must_use]
+    pub const fn is_bgm(self) -> bool {
+        self.0[0] == b'0' && self.0[1] == b'1'
+    }
+
     /// Converts the channel into a key mapping.
     #[must_use]
-    pub fn try_into_map<T: KeyLayoutMapper>(self) -> Option<T> {
+    pub fn try_into_map<T: BmsLayoutMapper>(self) -> Option<T> {
         T::from_channel_id(self)
+    }
+
+    /// Check if this is a visible note channel (P1: first digit '1', P2: first digit '2').
+    #[must_use]
+    pub const fn is_visible_note_channel(self) -> bool {
+        matches!(self.0[0], b'1' | b'2')
+    }
+
+    /// Convert a visible note channel to its long-note channel equivalent.
+    ///
+    /// P1 Visible (`1x`) → P1 Long (`5x`), P2 Visible (`2x`) → P2 Long (`6x`).
+    /// Returns `None` if this is not a visible note channel.
+    #[must_use]
+    pub const fn to_long_note_channel(self) -> Option<Self> {
+        if !self.is_visible_note_channel() {
+            return None;
+        }
+        let long_first = if self.0[0] == b'1' { b'5' } else { b'6' };
+        Some(Self([long_first, self.0[1]]))
     }
 }
 
@@ -335,4 +360,76 @@ pub fn read_channel(channel: &str) -> Option<Channel> {
     }
     let channel_id = channel.parse::<NoteChannelId>().ok()?;
     Some(Channel::Note { channel_id })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_visible_to_long_p1() {
+        let vis = NoteChannelId::try_from([b'1', b'1']).unwrap();
+        assert!(vis.is_visible_note_channel());
+        let long = vis.to_long_note_channel().unwrap();
+        assert_eq!(long, NoteChannelId::try_from([b'5', b'1']).unwrap());
+    }
+
+    #[test]
+    fn test_visible_to_long_p2() {
+        let vis = NoteChannelId::try_from([b'2', b'1']).unwrap();
+        assert!(vis.is_visible_note_channel());
+        let long = vis.to_long_note_channel().unwrap();
+        assert_eq!(long, NoteChannelId::try_from([b'6', b'1']).unwrap());
+    }
+
+    #[test]
+    fn test_non_visible_returns_none() {
+        let long = NoteChannelId::try_from([b'5', b'1']).unwrap();
+        assert!(!long.is_visible_note_channel());
+        assert!(long.to_long_note_channel().is_none());
+    }
+
+    #[test]
+    fn test_invisible_not_visible() {
+        let inv = NoteChannelId::try_from([b'3', b'1']).unwrap();
+        assert!(!inv.is_visible_note_channel());
+        assert!(inv.to_long_note_channel().is_none());
+    }
+
+    #[test]
+    fn test_bgm_not_visible() {
+        let bgm = NoteChannelId::bgm();
+        assert!(!bgm.is_visible_note_channel());
+    }
+
+    #[test]
+    fn test_landmine_not_visible() {
+        let landmine = NoteChannelId::try_from([b'D', b'1']).unwrap();
+        assert!(!landmine.is_visible_note_channel());
+        assert!(landmine.to_long_note_channel().is_none());
+    }
+
+    #[test]
+    fn test_bgm_is_bgm() {
+        let bgm = NoteChannelId::bgm();
+        assert!(bgm.is_bgm());
+    }
+
+    #[test]
+    fn test_visible_not_bgm() {
+        let vis = NoteChannelId::try_from([b'1', b'1']).unwrap();
+        assert!(!vis.is_bgm());
+    }
+
+    #[test]
+    fn test_long_not_bgm() {
+        let long = NoteChannelId::try_from([b'5', b'1']).unwrap();
+        assert!(!long.is_bgm());
+    }
+
+    #[test]
+    fn test_invisible_not_bgm() {
+        let inv = NoteChannelId::try_from([b'3', b'1']).unwrap();
+        assert!(!inv.is_bgm());
+    }
 }

--- a/src/bms/command/channel/mapper.rs
+++ b/src/bms/command/channel/mapper.rs
@@ -1,10 +1,10 @@
-//! For converting key/channel between different modes, please see [`KeyLayoutMapper`] enum and `convert_key_mapping_between` function.
+//! For converting key/channel between different modes, please see [`BmsLayoutMapper`] enum and `convert_key_mapping_between` function.
 
 use super::{Key, NoteChannelId, NoteKind, PlayerSide};
 use Key::*;
 
-/// Convert from [`KeyLayoutBeat`] to [`NoteChannelId`].
-fn key_layout_beat_to_channel_id(beat: KeyLayoutBeat) -> NoteChannelId {
+/// Convert from [`BmsLayoutBeat`] to [`NoteChannelId`].
+fn bms_layout_beat_to_channel_id(beat: BmsLayoutBeat) -> NoteChannelId {
     let (side, kind, key) = beat.as_tuple();
 
     // First character based on NoteKind and PlayerSide
@@ -32,8 +32,8 @@ fn key_layout_beat_to_channel_id(beat: KeyLayoutBeat) -> NoteChannelId {
         .expect("generated note channel id should be valid")
 }
 
-/// Convert from [`NoteChannelId`] to [`KeyLayoutBeat`].
-fn channel_id_to_key_layout_beat(channel_id: NoteChannelId) -> Option<KeyLayoutBeat> {
+/// Convert from [`NoteChannelId`] to [`BmsLayoutBeat`].
+fn channel_id_to_bms_layout_beat(channel_id: NoteChannelId) -> Option<BmsLayoutBeat> {
     let [first_char, second_char] = channel_id.0.map(|c| c as char);
 
     // Parse NoteKind and PlayerSide from first character
@@ -58,20 +58,20 @@ fn channel_id_to_key_layout_beat(channel_id: NoteChannelId) -> Option<KeyLayoutB
         _ => return None,
     };
 
-    Some(KeyLayoutBeat::new(side, kind, key))
+    Some(BmsLayoutBeat::new(side, kind, key))
 }
 
 /// A trait for key mapping storage structure.
-pub trait KeyMapping {
-    /// Create a new [`KeyMapping`] from a [`PlayerSide`], [`NoteKind`] and [`Key`].
+pub trait BmsLayout {
+    /// Create a new [`BmsLayout`] from a [`PlayerSide`], [`NoteKind`] and [`Key`].
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self;
-    /// Get the [`PlayerSide`] from this [`KeyMapping`].
+    /// Get the [`PlayerSide`] from this [`BmsLayout`].
     fn side(&self) -> PlayerSide;
-    /// Get the [`NoteKind`] from this [`KeyMapping`].
+    /// Get the [`NoteKind`] from this [`BmsLayout`].
     fn kind(&self) -> NoteKind;
-    /// Get the [`Key`] from this [`KeyMapping`].
+    /// Get the [`Key`] from this [`BmsLayout`].
     fn key(&self) -> Key;
-    /// Create a new [`KeyMapping`] from a tuple of [`PlayerSide`], [`NoteKind`] and [`Key`].
+    /// Create a new [`BmsLayout`] from a tuple of [`PlayerSide`], [`NoteKind`] and [`Key`].
     #[must_use]
     fn from_tuple(tuple: (PlayerSide, NoteKind, Key)) -> Self
     where
@@ -90,7 +90,7 @@ pub trait KeyMapping {
 /// This trait defines the interface for converting between different key channel modes
 /// and the standard [`NoteChannelId`] format. Each mode implementation should provide methods to
 /// convert from its own format to [`NoteChannelId`] format and vice versa.
-pub trait KeyLayoutMapper: KeyMapping {
+pub trait BmsLayoutMapper: BmsLayout {
     /// Convert from this mode's format to [`NoteChannelId`] format.
     ///
     /// This method takes a ([`PlayerSide`], [`NoteKind`], [`Key`]) tuple in this mode's format and converts
@@ -112,9 +112,9 @@ pub trait KeyLayoutMapper: KeyMapping {
 /// - Lanes:
 ///   - Chars: '1'..'7','6' scratch, '7' free zone, '8'->Key6, '9'->Key7
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct KeyLayoutBeat(pub PlayerSide, pub NoteKind, pub Key);
+pub struct BmsLayoutBeat(pub PlayerSide, pub NoteKind, pub Key);
 
-impl KeyMapping for KeyLayoutBeat {
+impl BmsLayout for BmsLayoutBeat {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
         Self(side, kind, key)
     }
@@ -132,13 +132,13 @@ impl KeyMapping for KeyLayoutBeat {
     }
 }
 
-impl KeyLayoutMapper for KeyLayoutBeat {
+impl BmsLayoutMapper for BmsLayoutBeat {
     fn to_channel_id(self) -> NoteChannelId {
-        key_layout_beat_to_channel_id(self)
+        bms_layout_beat_to_channel_id(self)
     }
 
     fn from_channel_id(channel_id: NoteChannelId) -> Option<Self> {
-        channel_id_to_key_layout_beat(channel_id)
+        channel_id_to_bms_layout_beat(channel_id)
     }
 }
 
@@ -147,9 +147,9 @@ impl KeyLayoutMapper for KeyLayoutBeat {
 /// - Lanes:
 ///   - Chars: '1'..'9', '6'->Key8, '7'->Key9, '8'->Key6, '9'->Key7
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct KeyLayoutPmsBmeType(pub PlayerSide, pub NoteKind, pub Key);
+pub struct BmsLayoutPmsBmeType(pub PlayerSide, pub NoteKind, pub Key);
 
-impl KeyMapping for KeyLayoutPmsBmeType {
+impl BmsLayout for BmsLayoutPmsBmeType {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
         Self(side, kind, key)
     }
@@ -167,7 +167,7 @@ impl KeyMapping for KeyLayoutPmsBmeType {
     }
 }
 
-impl KeyLayoutMapper for KeyLayoutPmsBmeType {
+impl BmsLayoutMapper for BmsLayoutPmsBmeType {
     fn to_channel_id(self) -> NoteChannelId {
         let (side, kind, key) = self.as_tuple();
         let key = match key {
@@ -175,12 +175,12 @@ impl KeyLayoutMapper for KeyLayoutPmsBmeType {
             Key(9) => FreeZone,
             other => other,
         };
-        let beat = KeyLayoutBeat::new(side, kind, key);
-        key_layout_beat_to_channel_id(beat)
+        let beat = BmsLayoutBeat::new(side, kind, key);
+        bms_layout_beat_to_channel_id(beat)
     }
 
     fn from_channel_id(channel_id: NoteChannelId) -> Option<Self> {
-        let beat = channel_id_to_key_layout_beat(channel_id)?;
+        let beat = channel_id_to_bms_layout_beat(channel_id)?;
         let (side, kind, key) = beat.as_tuple();
         let key = match key {
             Scratch(1) => Key(8),
@@ -197,9 +197,9 @@ impl KeyLayoutMapper for KeyLayoutPmsBmeType {
 ///   - Beat -> this: (P2,Key2..Key5) remapped to (P1,Key6..Key9); (P1,Key1..Key5) unchanged
 ///   - This -> Beat: Key6..Key9 => (P2,Key2..Key5); Key1..Key5 => (P1,Key1..Key5)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct KeyLayoutPms(pub PlayerSide, pub NoteKind, pub Key);
+pub struct BmsLayoutPms(pub PlayerSide, pub NoteKind, pub Key);
 
-impl KeyMapping for KeyLayoutPms {
+impl BmsLayout for BmsLayoutPms {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
         Self(side, kind, key)
     }
@@ -217,7 +217,7 @@ impl KeyMapping for KeyLayoutPms {
     }
 }
 
-impl KeyLayoutMapper for KeyLayoutPms {
+impl BmsLayoutMapper for BmsLayoutPms {
     fn to_channel_id(self) -> NoteChannelId {
         use PlayerSide::*;
         let (side, kind, key) = self.as_tuple();
@@ -226,13 +226,13 @@ impl KeyLayoutMapper for KeyLayoutPms {
             (Player1, Key(key_u8 @ 6..=9)) => (Player2, Key(key_u8 - 4)),
             other => other,
         };
-        let beat = KeyLayoutBeat::new(side, kind, key);
-        key_layout_beat_to_channel_id(beat)
+        let beat = BmsLayoutBeat::new(side, kind, key);
+        bms_layout_beat_to_channel_id(beat)
     }
 
     fn from_channel_id(channel_id: NoteChannelId) -> Option<Self> {
         use PlayerSide::*;
-        let beat = channel_id_to_key_layout_beat(channel_id)?;
+        let beat = channel_id_to_bms_layout_beat(channel_id)?;
         let (side, kind, key) = beat.as_tuple();
         let (side, key) = match (side, key) {
             (Player1, Key(1..=5)) => (Player1, key),
@@ -249,9 +249,9 @@ impl KeyLayoutMapper for KeyLayoutPms {
 ///   - Beat -> this: FreeZone=>FootPedal
 ///   - This -> Beat: FootPedal=>FreeZone
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct KeyLayoutBeatNanasi(pub PlayerSide, pub NoteKind, pub Key);
+pub struct BmsLayoutBeatNanasi(pub PlayerSide, pub NoteKind, pub Key);
 
-impl KeyMapping for KeyLayoutBeatNanasi {
+impl BmsLayout for BmsLayoutBeatNanasi {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
         Self(side, kind, key)
     }
@@ -269,16 +269,16 @@ impl KeyMapping for KeyLayoutBeatNanasi {
     }
 }
 
-impl KeyLayoutMapper for KeyLayoutBeatNanasi {
+impl BmsLayoutMapper for BmsLayoutBeatNanasi {
     fn to_channel_id(self) -> NoteChannelId {
         let (side, kind, key) = self.as_tuple();
         let key = if let FootPedal = key { FreeZone } else { key };
-        let beat = KeyLayoutBeat::new(side, kind, key);
-        key_layout_beat_to_channel_id(beat)
+        let beat = BmsLayoutBeat::new(side, kind, key);
+        bms_layout_beat_to_channel_id(beat)
     }
 
     fn from_channel_id(channel_id: NoteChannelId) -> Option<Self> {
-        let beat = channel_id_to_key_layout_beat(channel_id)?;
+        let beat = channel_id_to_bms_layout_beat(channel_id)?;
         let (side, kind, key) = beat.as_tuple();
         let key = if let FreeZone = key { FootPedal } else { key };
         Some(Self::new(side, kind, key))
@@ -291,9 +291,9 @@ impl KeyLayoutMapper for KeyLayoutBeatNanasi {
 ///   - Beat -> this: (P2,Key1)=>FootPedal, (P2,Key2..Key7)=>Key8..Key13, (P2,Scratch)=>ScratchExtra; (P1,Key1..Key7|Scratch) unchanged; side becomes P1
 ///   - This -> Beat: reverse of above
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct KeyLayoutDscOctFp(pub PlayerSide, pub NoteKind, pub Key);
+pub struct BmsLayoutDscOctFp(pub PlayerSide, pub NoteKind, pub Key);
 
-impl KeyMapping for KeyLayoutDscOctFp {
+impl BmsLayout for BmsLayoutDscOctFp {
     fn new(side: PlayerSide, kind: NoteKind, key: Key) -> Self {
         Self(side, kind, key)
     }
@@ -311,7 +311,7 @@ impl KeyMapping for KeyLayoutDscOctFp {
     }
 }
 
-impl KeyLayoutMapper for KeyLayoutDscOctFp {
+impl BmsLayoutMapper for BmsLayoutDscOctFp {
     fn to_channel_id(self) -> NoteChannelId {
         use PlayerSide::*;
         let (side, kind, key) = self.as_tuple();
@@ -322,13 +322,13 @@ impl KeyLayoutMapper for KeyLayoutDscOctFp {
             (Player1, Key(key_u8 @ 8..=13)) => (Player2, Key(key_u8 - 6)),
             (s, other) => (s, other),
         };
-        let beat = KeyLayoutBeat::new(side, kind, key);
-        key_layout_beat_to_channel_id(beat)
+        let beat = BmsLayoutBeat::new(side, kind, key);
+        bms_layout_beat_to_channel_id(beat)
     }
 
     fn from_channel_id(channel_id: NoteChannelId) -> Option<Self> {
         use PlayerSide::*;
-        let beat = channel_id_to_key_layout_beat(channel_id)?;
+        let beat = channel_id_to_bms_layout_beat(channel_id)?;
         let (side, kind, key) = beat.as_tuple();
         let (side, key) = match (side, key) {
             (Player1, Key(1..=7) | Scratch(1)) => (Player1, key),

--- a/src/bms/model.rs
+++ b/src/bms/model.rs
@@ -389,4 +389,53 @@ impl Bms {
         // randomized
         self.randomized.extend(other.randomized.clone());
     }
+
+    /// Check for playing warnings and errors based on the parsed BMS data.
+    ///
+    /// This method inspects the parsed BMS data for conditions that would affect
+    /// playback, such as missing BPM, missing TOTAL, or no playable notes.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - Key layout mapper type (e.g., [`BmsLayoutBeat`], [`BmsLayoutBeatNanasi`])
+    pub fn check_playing<T: BmsLayoutMapper>(&self) -> PlayingCheckOutput {
+        let mut playing_warnings = Vec::new();
+        let mut playing_errors = Vec::new();
+
+        // Check for TotalUndefined warning
+        if self.judge.total.is_none() {
+            playing_warnings.push(PlayingWarning::TotalUndefined);
+        }
+
+        // Check for BPM-related conditions
+        if self.bpm.bpm.is_none() {
+            if self.bpm.bpm_changes.is_empty() {
+                playing_errors.push(PlayingError::BpmUndefined);
+            } else {
+                playing_warnings.push(PlayingWarning::StartBpmUndefined);
+            }
+        }
+
+        // Check for notes
+        if self.wav.notes.is_empty() {
+            playing_errors.push(PlayingError::NoNotes);
+        } else {
+            // Check for displayable notes (Visible, Long, Landmine)
+            let has_displayable = self.wav.notes.displayables::<T>().next().is_some();
+            if !has_displayable {
+                playing_warnings.push(PlayingWarning::NoDisplayableNotes);
+            }
+
+            // Check for playable notes (all except Invisible)
+            let has_playable = self.wav.notes.playables::<T>().next().is_some();
+            if !has_playable {
+                playing_warnings.push(PlayingWarning::NoPlayableNotes);
+            }
+        }
+
+        PlayingCheckOutput {
+            playing_warnings,
+            playing_errors,
+        }
+    }
 }

--- a/src/bms/model/control_flow.rs
+++ b/src/bms/model/control_flow.rs
@@ -198,9 +198,12 @@ impl RandomizedObjects {
 
     /// Exports this randomized block as `#RANDOM/#SETRANDOM + #IF/#ELSEIF/#ENDIF` tokens.
     ///
-    /// Branch contents are exported via `Bms::unparse::<T>()` for each branch in condition order.
+    /// Branch contents are exported via the provided `unparse_fn` for each branch.
     #[must_use]
-    pub fn export_as_random<'a, T: KeyLayoutMapper>(&'a self) -> Vec<Token<'a>> {
+    pub fn export_as_random<'a, F>(&'a self, unparse_fn: &F) -> Vec<Token<'a>>
+    where
+        F: Fn(&'a Bms) -> Vec<Token<'a>>,
+    {
         let mut tokens: Vec<Token<'a>> = Vec::new();
 
         let Some(gval) = &self.generating else {
@@ -224,14 +227,14 @@ impl RandomizedObjects {
                 name: "IF".into(),
                 args: cond.to_string().into(),
             });
-            tokens.extend(branch.sub.as_ref().unparse::<T>());
+            tokens.extend(unparse_fn(branch.sub.as_ref()));
         }
         for (cond, branch) in iter {
             tokens.push(Token::Header {
                 name: "ELSEIF".into(),
                 args: cond.to_string().into(),
             });
-            tokens.extend(branch.sub.as_ref().unparse::<T>());
+            tokens.extend(unparse_fn(branch.sub.as_ref()));
         }
 
         tokens.push(Token::Header {
@@ -248,9 +251,12 @@ impl RandomizedObjects {
 
     /// Exports this randomized block as `#SWITCH/#SETSWITCH + #CASE/#SKIP/#ENDSW` tokens.
     ///
-    /// Branch contents are exported via `Bms::unparse::<T>()` for each `#CASE` in condition order.
+    /// Branch contents are exported via the provided `unparse_fn` for each `#CASE` in condition order.
     #[must_use]
-    pub fn export_as_switch<'a, T: KeyLayoutMapper>(&'a self) -> Vec<Token<'a>> {
+    pub fn export_as_switch<'a, F>(&'a self, unparse_fn: &F) -> Vec<Token<'a>>
+    where
+        F: Fn(&'a Bms) -> Vec<Token<'a>>,
+    {
         let mut tokens: Vec<Token<'a>> = Vec::new();
 
         let Some(gval) = &self.generating else {
@@ -273,7 +279,7 @@ impl RandomizedObjects {
                 name: "CASE".into(),
                 args: cond.to_string().into(),
             });
-            tokens.extend(branch.sub.as_ref().unparse::<T>());
+            tokens.extend(unparse_fn(branch.sub.as_ref()));
             tokens.push(Token::Header {
                 name: "SKIP".into(),
                 args: "".into(),

--- a/src/bms/model/notes.rs
+++ b/src/bms/model/notes.rs
@@ -143,12 +143,12 @@ impl Notes {
     /// ```rust
     /// # use bms_rs::bms::prelude::*;
     /// # let notes = Notes::default();
-    /// notes.playables::<KeyLayoutBeat>().filter(|obj| !obj.wav_id.is_null())
+    /// notes.playables::<BmsLayoutBeat>().filter(|obj| !obj.wav_id.is_null())
     /// # ;
     /// ```
     pub fn playables<T>(&self) -> impl Iterator<Item = &WavObj>
     where
-        T: KeyLayoutMapper,
+        T: BmsLayoutMapper,
     {
         self.arena.0.iter().sorted().filter(|obj| {
             obj.channel_id
@@ -170,12 +170,12 @@ impl Notes {
     /// ```rust
     /// # use bms_rs::bms::prelude::*;
     /// # let notes = Notes::default();
-    /// notes.displayables::<KeyLayoutBeat>().filter(|obj| !obj.wav_id.is_null())
+    /// notes.displayables::<BmsLayoutBeat>().filter(|obj| !obj.wav_id.is_null())
     /// # ;
     /// ```
     pub fn displayables<T>(&self) -> impl Iterator<Item = &WavObj>
     where
-        T: KeyLayoutMapper,
+        T: BmsLayoutMapper,
     {
         self.arena.0.iter().sorted().filter(|obj| {
             obj.channel_id
@@ -197,12 +197,12 @@ impl Notes {
     /// ```rust
     /// # use bms_rs::bms::prelude::*;
     /// # let notes = Notes::default();
-    /// notes.bgms::<KeyLayoutBeat>().filter(|obj| !obj.wav_id.is_null())
+    /// notes.bgms::<BmsLayoutBeat>().filter(|obj| !obj.wav_id.is_null())
     /// # ;
     /// ```
     pub fn bgms<T>(&self) -> impl Iterator<Item = &WavObj>
     where
-        T: KeyLayoutMapper,
+        T: BmsLayoutMapper,
     {
         self.arena.0.iter().sorted().filter(|obj| {
             obj.channel_id
@@ -225,14 +225,14 @@ impl Notes {
     /// # use bms_rs::bms::prelude::*;
     /// # let notes = Notes::default();
     /// let channel_id = NoteChannelId::try_from(['0', '1']).unwrap();
-    /// notes.notes_on::<KeyLayoutBeat>(channel_id).filter(|(_, obj)| !obj.wav_id.is_null());
+    /// notes.notes_on::<BmsLayoutBeat>(channel_id).filter(|(_, obj)| !obj.wav_id.is_null());
     /// ```
     pub fn notes_on<T>(
         &self,
         channel_id: NoteChannelId,
     ) -> impl Iterator<Item = (WavObjArenaIndex, &WavObj)>
     where
-        T: KeyLayoutMapper,
+        T: BmsLayoutMapper,
     {
         self.idx_by_channel
             .get(&channel_id)
@@ -297,7 +297,7 @@ impl Notes {
     #[must_use]
     pub fn last_playable_time<T>(&self) -> Option<ObjTime>
     where
-        T: KeyLayoutMapper,
+        T: BmsLayoutMapper,
     {
         self.notes_in(..)
             .map(|(_, obj)| obj)
@@ -316,7 +316,7 @@ impl Notes {
     #[must_use]
     pub fn last_bgm_time<T>(&self) -> Option<ObjTime>
     where
-        T: KeyLayoutMapper,
+        T: BmsLayoutMapper,
     {
         self.notes_in(..)
             .map(|(_, obj)| obj)
@@ -388,10 +388,7 @@ impl Notes {
     }
 
     /// Removes notes belonging to the wav id.
-    pub fn remove_note<T>(&mut self, wav_id: ObjId) -> Vec<WavObj>
-    where
-        T: KeyLayoutMapper,
-    {
+    pub fn remove_note(&mut self, wav_id: ObjId) -> Vec<WavObj> {
         let Some(indexes) = self.idx_by_wav_id.remove(&wav_id) else {
             return vec![];
         };
@@ -415,10 +412,7 @@ impl Notes {
     }
 
     /// Removes the latest note using the wav of `wav_id`.
-    pub fn pop_latest_of<T>(&mut self, wav_id: ObjId) -> Option<WavObj>
-    where
-        T: KeyLayoutMapper,
-    {
+    pub fn pop_latest_of(&mut self, wav_id: ObjId) -> Option<WavObj> {
         let &WavObjArenaIndex(to_pop) = self.idx_by_wav_id.get(&wav_id)?.last()?;
         let removing = std::mem::replace(self.arena.0.get_mut(to_pop)?, WavObj::dangling());
         self.remove_index(to_pop, &removing);
@@ -426,10 +420,7 @@ impl Notes {
     }
 
     /// Adds the BGM (auto-played) note of `wav_id` at `time`.
-    pub fn push_bgm<T>(&mut self, time: ObjTime, wav_id: ObjId)
-    where
-        T: KeyLayoutMapper,
-    {
+    pub fn push_bgm(&mut self, time: ObjTime, wav_id: ObjId) {
         self.push_note(WavObj {
             offset: time,
             channel_id: NoteChannelId::bgm(),
@@ -438,10 +429,7 @@ impl Notes {
     }
 
     /// Retains note objects with the condition `cond`. It keeps only the [`WavObj`]s which `cond` returned `true`.
-    pub fn retain_notes<T, F: FnMut(&WavObj) -> bool>(&mut self, mut cond: F)
-    where
-        T: KeyLayoutMapper,
-    {
+    pub fn retain_notes<F: FnMut(&WavObj) -> bool>(&mut self, mut cond: F) {
         let removing_indexes: Vec<_> = self
             .arena
             .0
@@ -566,14 +554,14 @@ mod tests {
         let (idx, _) = notes.all_entries().next().unwrap();
         notes.change_note_channel(
             [idx],
-            KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1)).to_channel_id(),
+            BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1)).to_channel_id(),
         );
 
         assert_eq!(
             notes.all_notes().next(),
             Some(&WavObj {
                 offset: ObjTime::new(1, 2, 4,).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: ObjId::try_from("01", false).unwrap(),
             })

--- a/src/bms/parse.rs
+++ b/src/bms/parse.rs
@@ -24,7 +24,7 @@ use crate::bms::{
     ParseConfig,
     command::{
         ObjId,
-        channel::{Channel, mapper::KeyLayoutMapper},
+        channel::Channel,
         mixin::SourceRangeMixin,
         time::{ObjTime, Track},
     },
@@ -139,9 +139,9 @@ pub struct ParseOutput {
 
 impl Bms {
     /// Parses a token stream into [`Bms`] without AST.
-    pub fn from_token_stream<'a, T: KeyLayoutMapper, P: Prompter, R: Rng, M: TokenModifier>(
+    pub fn from_token_stream<'a, P: Prompter, R: Rng, M: TokenModifier>(
         token_iter: impl IntoIterator<Item = &'a TokenWithRange<'a>>,
-        config: ParseConfig<T, P, R, M>,
+        config: ParseConfig<P, R, M>,
     ) -> ParseOutput {
         let tokens: Vec<_> = token_iter.into_iter().collect();
         let mut tokens_slice = tokens.as_slice();

--- a/src/bms/parse/check_playing.rs
+++ b/src/bms/parse/check_playing.rs
@@ -3,9 +3,6 @@
 use thiserror::Error;
 
 use crate::bms::command::ObjId;
-use crate::bms::command::channel::mapper::KeyLayoutMapper;
-
-use crate::bms::model::Bms;
 
 #[cfg(feature = "diagnostics")]
 use crate::diagnostics::{SimpleSource, ToAriadne, build_report};
@@ -146,48 +143,4 @@ pub struct PlayingCheckOutput {
     pub playing_warnings: Vec<PlayingWarning>,
     /// List of [`PlayingError`]s.
     pub playing_errors: Vec<PlayingError>,
-}
-
-impl Bms {
-    /// Check for playing warnings and errors based on the parsed BMS data.
-    pub fn check_playing<T: KeyLayoutMapper>(&self) -> PlayingCheckOutput {
-        let mut playing_warnings = Vec::new();
-        let mut playing_errors = Vec::new();
-
-        // Check for TotalUndefined warning
-        if self.judge.total.is_none() {
-            playing_warnings.push(PlayingWarning::TotalUndefined);
-        }
-
-        // Check for BPM-related conditions
-        if self.bpm.bpm.is_none() {
-            if self.bpm.bpm_changes.is_empty() {
-                playing_errors.push(PlayingError::BpmUndefined);
-            } else {
-                playing_warnings.push(PlayingWarning::StartBpmUndefined);
-            }
-        }
-
-        // Check for notes
-        if self.wav.notes.is_empty() {
-            playing_errors.push(PlayingError::NoNotes);
-        } else {
-            // Check for displayable notes (Visible, Long, Landmine)
-            let has_displayable = self.wav.notes.displayables::<T>().next().is_some();
-            if !has_displayable {
-                playing_warnings.push(PlayingWarning::NoDisplayableNotes);
-            }
-
-            // Check for playable notes (all except Invisible)
-            let has_playable = self.wav.notes.playables::<T>().next().is_some();
-            if !has_playable {
-                playing_warnings.push(PlayingWarning::NoPlayableNotes);
-            }
-        }
-
-        PlayingCheckOutput {
-            playing_warnings,
-            playing_errors,
-        }
-    }
 }

--- a/src/bms/parse/token_processor.rs
+++ b/src/bms/parse/token_processor.rs
@@ -230,9 +230,7 @@ where
 }
 
 /// Returns all of processors this crate provided.
-pub fn full_preset<T: KeyLayoutMapper, R: Rng>(
-    rng: Rc<RefCell<R>>,
-) -> impl TokenProcessor<Output = Bms> {
+pub fn full_preset<R: Rng>(rng: Rc<RefCell<R>>) -> impl TokenProcessor<Output = Bms> {
     let case_sensitive_obj_id = Rc::new(RefCell::new(false));
     let sub_processor = repr::RepresentationProcessor::new(&case_sensitive_obj_id)
         .then(bmp::BmpProcessor::new(&case_sensitive_obj_id))
@@ -253,7 +251,7 @@ pub fn full_preset<T: KeyLayoutMapper, R: Rng>(
         .then(text::TextProcessor::new(&case_sensitive_obj_id))
         .then(video::VideoProcessor::new(&case_sensitive_obj_id))
         .then(volume::VolumeProcessor)
-        .then(wav::WavProcessor::<T>::new(&case_sensitive_obj_id));
+        .then(wav::WavProcessor::new(&case_sensitive_obj_id));
 
     let bms_mapper = sub_processor.map(
         |(

--- a/src/bms/parse/token_processor/wav.rs
+++ b/src/bms/parse/token_processor/wav.rs
@@ -17,7 +17,7 @@
 //! - `#xxx[D1-DZ]:` - Player 1 landmine channel with damage amount.
 //! - `#xxx[E1-EZ]:` - Player 2 landmine channel with damage amount.
 
-use std::{cell::RefCell, marker::PhantomData, path::Path, rc::Rc};
+use std::{cell::RefCell, path::Path, rc::Rc};
 
 use super::{
     super::prompt::{DefDuplication, Prompter},
@@ -35,21 +35,19 @@ use crate::{
 
 /// It processes `#WAVxx` and `#LNOBJ` definitions and objects on `Bgm` and `Note` channels.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct WavProcessor<T> {
+pub struct WavProcessor {
     case_sensitive_obj_id: Rc<RefCell<bool>>,
-    _phantom: PhantomData<fn() -> T>,
 }
 
-impl<T: KeyLayoutMapper> WavProcessor<T> {
+impl WavProcessor {
     pub fn new(case_sensitive_obj_id: &Rc<RefCell<bool>>) -> Self {
         Self {
             case_sensitive_obj_id: Rc::clone(case_sensitive_obj_id),
-            _phantom: PhantomData,
         }
     }
 }
 
-impl<T: KeyLayoutMapper> TokenProcessor for WavProcessor<T> {
+impl TokenProcessor for WavProcessor {
     type Output = WavObjects;
 
     fn process<P: Prompter>(
@@ -81,7 +79,7 @@ impl<T: KeyLayoutMapper> TokenProcessor for WavProcessor<T> {
     }
 }
 
-impl<T: KeyLayoutMapper> WavProcessor<T> {
+impl WavProcessor {
     fn on_header(
         &self,
         name: &str,
@@ -190,7 +188,7 @@ impl<T: KeyLayoutMapper> WavProcessor<T> {
             let end_id = ObjId::try_from(args, *self.case_sensitive_obj_id.borrow())?;
             let mut end_note = objects
                 .notes
-                .pop_latest_of::<T>(end_id)
+                .pop_latest_of(end_id)
                 .ok_or(ParseWarning::UndefinedObject(end_id))?;
             let WavObj {
                 offset, channel_id, ..
@@ -210,30 +208,22 @@ impl<T: KeyLayoutMapper> WavProcessor<T> {
                 ParseWarning::SyntaxError(format!("Cannot find begin note for LNOBJ {end_id:?}"))
             })?;
 
-            let mut begin_note_tuple = begin_note
-                .channel_id
-                .try_into_map::<T>()
-                .ok_or_else(|| {
-                    ParseWarning::SyntaxError(format!(
-                        "channel of specified note for LNOBJ cannot become LN {end_id:?}"
-                    ))
-                })?
-                .as_tuple();
-            begin_note_tuple.1 = NoteKind::Long;
-            begin_note.channel_id = T::from_tuple(begin_note_tuple).to_channel_id();
+            begin_note.channel_id =
+                begin_note
+                    .channel_id
+                    .to_long_note_channel()
+                    .ok_or_else(|| {
+                        ParseWarning::SyntaxError(format!(
+                            "channel of specified note for LNOBJ cannot become LN {end_id:?}"
+                        ))
+                    })?;
             objects.notes.push_note(begin_note);
 
-            let mut end_note_tuple = end_note
-                .channel_id
-                .try_into_map::<T>()
-                .ok_or_else(|| {
-                    ParseWarning::SyntaxError(format!(
-                        "channel of specified note for LNOBJ cannot become LN {end_id:?}"
-                    ))
-                })?
-                .as_tuple();
-            end_note_tuple.1 = NoteKind::Long;
-            end_note.channel_id = T::from_tuple(end_note_tuple).to_channel_id();
+            end_note.channel_id = end_note.channel_id.to_long_note_channel().ok_or_else(|| {
+                ParseWarning::SyntaxError(format!(
+                    "channel of specified note for LNOBJ cannot become LN {end_id:?}"
+                ))
+            })?;
             objects.notes.push_note(end_note);
         }
         if name.eq_ignore_ascii_case("WAVCMD") {
@@ -298,7 +288,7 @@ impl<T: KeyLayoutMapper> WavProcessor<T> {
             let (pairs, w) = parse_obj_ids(track, message, &self.case_sensitive_obj_id);
             warnings.extend(w);
             for (time, obj) in pairs {
-                objects.notes.push_bgm::<T>(time, obj);
+                objects.notes.push_bgm(time, obj);
             }
         }
         if let Channel::Note { channel_id } = channel {

--- a/src/bms/parse/validity.rs
+++ b/src/bms/parse/validity.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::bms::{
     command::{ObjId, time::ObjTime},
     model::{Bms, obj::WavObj},
-    prelude::{KeyLayoutBeat, KeyLayoutMapper, KeyMapping},
+    prelude::{BmsLayout, BmsLayoutBeat, BmsLayoutMapper},
 };
 use crate::chart::types::{Key, NoteKind, PlayerSide};
 
@@ -170,7 +170,7 @@ impl Bms {
         let mut lane_to_notes: HashMap<Key, Vec<&WavObj>> = HashMap::new();
         for obj in self.wav.notes.all_notes() {
             // Visible note in section 000 (track index 0)
-            let Some(map) = KeyLayoutBeat::from_channel_id(obj.channel_id) else {
+            let Some(map) = BmsLayoutBeat::from_channel_id(obj.channel_id) else {
                 continue;
             };
             if map.kind().is_playable() && obj.offset.track().0 == 0 {
@@ -194,7 +194,7 @@ impl Bms {
             let long_times: Vec<ObjTime> = lane_objs
                 .iter()
                 .filter_map(|o| {
-                    let map = KeyLayoutBeat::from_channel_id(o.channel_id)?;
+                    let map = BmsLayoutBeat::from_channel_id(o.channel_id)?;
                     (map.kind() == NoteKind::Long).then_some(o.offset)
                 })
                 .collect();
@@ -204,7 +204,7 @@ impl Bms {
             for (single_obj, map) in lane_objs
                 .iter()
                 .filter_map(|obj| {
-                    KeyLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
+                    BmsLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
                 })
                 .filter(|(_, map)| map.kind() == NoteKind::Visible)
             {
@@ -221,7 +221,7 @@ impl Bms {
             for (landmine_obj, map) in lane_objs
                 .iter()
                 .filter_map(|obj| {
-                    KeyLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
+                    BmsLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
                 })
                 .filter(|(_, map)| map.kind() == NoteKind::Landmine)
             {
@@ -274,7 +274,7 @@ impl Bms {
             for (single_obj, map) in lane_objs
                 .iter()
                 .filter_map(|obj| {
-                    KeyLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
+                    BmsLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
                 })
                 .filter(|(_, map)| map.kind() == NoteKind::Visible)
             {
@@ -295,7 +295,7 @@ impl Bms {
             for (landmine_obj, map) in lane_objs
                 .iter()
                 .filter_map(|obj| {
-                    KeyLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
+                    BmsLayoutBeat::from_channel_id(obj.channel_id).map(|map| (obj, map))
                 })
                 .filter(|(_, map)| map.kind() == NoteKind::Landmine)
             {
@@ -341,7 +341,7 @@ mod tests {
         let mut notes = Notes::default();
         notes.push_note(WavObj {
             offset: time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id,
         });
@@ -376,7 +376,7 @@ mod tests {
         let mut notes = Notes::default();
         notes.push_note(WavObj {
             offset: time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id,
         });
@@ -398,13 +398,13 @@ mod tests {
         let mut notes = Notes::default();
         notes.push_note(WavObj {
             offset: time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id1,
         });
         notes.push_note(WavObj {
             offset: time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id2,
         });
@@ -430,21 +430,21 @@ mod tests {
         // LN start
         notes.push_note(WavObj {
             offset: ln_start,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_s,
         });
         // LN end
         notes.push_note(WavObj {
             offset: ln_end,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_e,
         });
         // Visible inside LN interval
         notes.push_note(WavObj {
             offset: vis_time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_vis,
         });
@@ -470,20 +470,20 @@ mod tests {
         // LN interval
         notes.push_note(WavObj {
             offset: ln_start,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_s,
         });
         notes.push_note(WavObj {
             offset: ln_end,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_e,
         });
         // Landmine inside the LN
         notes.push_note(WavObj {
             offset: mine_time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Landmine, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Landmine, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_mine,
         });
@@ -505,13 +505,13 @@ mod tests {
         let mut notes = Notes::default();
         notes.push_note(WavObj {
             offset: time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_vis,
         });
         notes.push_note(WavObj {
             offset: time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Landmine, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Landmine, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_mine,
         });
@@ -537,13 +537,13 @@ mod tests {
         // Zero-length long note: start and end at same time
         notes.push_note(WavObj {
             offset: zero_length_time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_start,
         });
         notes.push_note(WavObj {
             offset: zero_length_time, // Same time - zero length
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Long, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_ln_end,
         });
@@ -551,7 +551,7 @@ mod tests {
         // Visible note at the same time as zero-length LN
         notes.push_note(WavObj {
             offset: vis_time,
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                 .to_channel_id(),
             wav_id: id_vis,
         });

--- a/src/bms/prelude.rs
+++ b/src/bms/prelude.rs
@@ -20,8 +20,8 @@ pub use super::{
                 PlayerSideKeyConverter,
             },
             mapper::{
-                KeyLayoutBeat, KeyLayoutBeatNanasi, KeyLayoutDscOctFp, KeyLayoutMapper,
-                KeyLayoutPms, KeyLayoutPmsBmeType, KeyMapping,
+                BmsLayout, BmsLayoutBeat, BmsLayoutBeatNanasi, BmsLayoutDscOctFp, BmsLayoutMapper,
+                BmsLayoutPms, BmsLayoutPmsBmeType,
             },
             read_channel,
         },
@@ -68,9 +68,6 @@ pub use super::{
     parse_bms,
     rng::{Rng, RngMock},
 };
-
-// Re-export process module
-pub use super::process::BmsProcessor;
 
 // Re-export chart event types (including BmsEvent)
 pub use crate::chart::event::BmsEvent;

--- a/src/bms/process.rs
+++ b/src/bms/process.rs
@@ -1,7 +1,7 @@
 //! Bms Processor Module.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     convert::TryFrom,
     path::PathBuf,
 };
@@ -25,7 +25,7 @@ use strict_num_extended::NonNegativeF64;
 ///
 /// This struct serves as a namespace for BMS parsing functions.
 /// It parses BMS files and returns a `Chart` containing all precomputed data.
-pub struct BmsProcessor;
+struct BmsProcessor;
 
 /// Convert STOP duration from 192nd-note units to beats (measure units).
 ///
@@ -45,7 +45,7 @@ impl BmsProcessor {
     /// # Errors
     ///
     /// Returns [`PlayingError::InvalidBpm`] if the BPM value could not be parsed.
-    pub fn parse<T: KeyLayoutMapper>(bms: &Bms) -> Result<Chart, PlayingError> {
+    fn parse<T: BmsLayoutMapper>(bms: &Bms) -> Result<Chart, PlayingError> {
         // === Validate all StringValue definitions ===
         let mut errors = Vec::new();
 
@@ -156,7 +156,7 @@ impl BmsProcessor {
     }
 
     /// Generate measure lines for BMS (generated for each track, but not exceeding other objects' Y values)
-    pub fn generate_barlines_for_bms(
+    fn generate_barlines_for_bms(
         bms: &Bms,
         y_memo: &YMemo,
         events_map: &mut BTreeMap<YCoordinate, Vec<PlayheadEvent>>,
@@ -189,7 +189,7 @@ impl BmsProcessor {
         }
     }
 
-    pub(crate) fn lane_of_channel_id<T: KeyLayoutMapper>(
+    fn lane_of_channel_id<T: BmsLayoutMapper>(
         channel_id: NoteChannelId,
     ) -> Option<(PlayerSide, Key, NoteKind)> {
         let map = channel_id.try_into_map::<T>()?;
@@ -359,31 +359,68 @@ impl YMemo {
     }
 }
 
+struct EventAppender<'a> {
+    bms: &'a Bms,
+    events_map: &'a mut BTreeMap<YCoordinate, Vec<PlayheadEvent>>,
+    id_gen: &'a mut ChartEventIdGenerator,
+    get_event_y: &'a dyn Fn(ObjTime) -> YCoordinate,
+}
+
 impl AllEventsIndex {
     /// Precompute all events, store grouped by Y coordinate
-    /// Note: Speed effects are calculated into event positions during initialization, ensuring event trigger times remain unchanged
     #[must_use]
-    pub fn precompute_all_events<T: KeyLayoutMapper>(bms: &Bms, y_memo: &YMemo) -> Self {
+    pub fn precompute_all_events<T: BmsLayoutMapper>(bms: &Bms, y_memo: &YMemo) -> Self {
         let mut events_map: BTreeMap<YCoordinate, Vec<PlayheadEvent>> = BTreeMap::new();
         let mut id_gen: ChartEventIdGenerator = ChartEventIdGenerator::default();
-
         let get_event_y = |time: ObjTime| -> YCoordinate { y_memo.get_y(time) };
 
-        let note_events: Vec<(YCoordinate, WavObj)> = bms
+        {
+            let mut appender = EventAppender {
+                bms,
+                events_map: &mut events_map,
+                id_gen: &mut id_gen,
+                get_event_y: &get_event_y,
+            };
+            appender.append_note_events::<T>(y_memo);
+            appender.append_bpm_events();
+            appender.append_scroll_events();
+            appender.append_speed_events();
+            appender.append_stop_events();
+            appender.append_bga_events();
+            appender.append_volume_events();
+            appender.append_text_events();
+            appender.append_judge_events();
+            appender.append_video_events();
+            appender.append_option_events();
+        }
+
+        BmsProcessor::generate_barlines_for_bms(bms, y_memo, &mut events_map, &mut id_gen);
+        Self::new(events_map)
+    }
+}
+
+impl EventAppender<'_> {
+    fn push_event(&mut self, y: YCoordinate, event: ChartEvent) {
+        let id = self.id_gen.next_id();
+        self.events_map
+            .entry(y)
+            .or_default()
+            .push(PlayheadEvent::new(id, y, event, TimeSpan::ZERO));
+    }
+
+    fn append_note_events<T: BmsLayoutMapper>(&mut self, y_memo: &YMemo) {
+        let note_events: Vec<(YCoordinate, WavObj)> = self
+            .bms
             .notes()
             .all_notes()
-            .map(|obj| (get_event_y(obj.offset), obj.clone()))
+            .map(|obj| (y_memo.get_y(obj.offset), obj.clone()))
             .sorted_by(|(y1, _), (y2, _)| y1.cmp(y2))
             .collect();
 
-        // Use ordered Vec instead of HashMap since f64 doesn't implement Hash
-        // and NonNegativeF64 doesn't implement Hash either
         let mut zero_length_key_tracker: Vec<(YCoordinate, PlayerSide, Key, usize)> = Vec::new();
-
         for (i, (y, obj)) in note_events.iter().enumerate() {
             let is_zero_length_section = y_memo.zero_length_tracks.contains(&obj.offset.track());
             let lane = BmsProcessor::lane_of_channel_id::<T>(obj.channel_id);
-
             if let Some((side, key, _)) = lane
                 && is_zero_length_section
             {
@@ -391,27 +428,7 @@ impl AllEventsIndex {
             }
         }
 
-        // Track LN start markers to prevent double-triggering (BMS format concern only).
-        //
-        // BMS format represents long notes using two consecutive Long note markers:
-        //   - First marker: start of long note (with length calculated to next marker)
-        //   - Second marker: end of long note (with no length)
-        //
-        // Example in BMS format:
-        //   #00151:11  <- Long note start (Player1, Key1, time=1)
-        //   #00351:22  <- Long note end   (Player1, Key1, time=3)
-        //
-        // Without this fix, both markers would trigger events, causing:
-        //   1. Double-triggering: same long note fires twice (at start and end)
-        //   2. Incorrect playback: end marker creates a zero-length note event
-        //
-        // IMPORTANT: This is purely a BMS FORMAT PARSING concern.
-        // The term "started" here refers to PARSING STATE, not GAMEPLAY STATE.
-        // The actual LN visibility (including LNs whose start has passed)
-        // is handled by AllEventsIndex using precomputed indices.
-        let mut ln_start_markers: std::collections::HashSet<(PlayerSide, Key)> =
-            std::collections::HashSet::new();
-
+        let mut ln_start_markers: HashSet<(PlayerSide, Key)> = HashSet::new();
         for (i, (y, obj)) in note_events.iter().enumerate() {
             let is_zero_length_section = y_memo.zero_length_tracks.contains(&obj.offset.track());
             let lane = BmsProcessor::lane_of_channel_id::<T>(obj.channel_id);
@@ -423,22 +440,7 @@ impl AllEventsIndex {
             };
 
             if should_include {
-                let event = event_for_note_static::<T>(bms, y_memo, obj);
-
-                // Fix double-triggering by skipping LN end markers.
-                //
-                // Logic:
-                //   - When we encounter a Long note:
-                //     * If its lane already has a start marker → this is the END marker, skip it
-                //     * If its lane has no start marker AND it has length → this is the START marker, track it
-                //     * If its lane has no start marker AND no length → edge case, ignore (no next marker)
-                //
-                // Result: Each long note generates exactly one event with the correct length.
-                //
-                // IMPORTANT: This is purely a BMS FORMAT PARSING concern.
-                // The term "started" here refers to PARSING STATE, not GAMEPLAY STATE.
-                // The actual LN visibility (including LNs whose start has passed)
-                // is handled by AllEventsIndex using precomputed indices.
+                let event = event_for_note_static::<T>(self.bms, y_memo, obj);
                 if let ChartEvent::Note {
                     side,
                     key,
@@ -449,228 +451,153 @@ impl AllEventsIndex {
                 {
                     let lane_key = (*side, *key);
                     if ln_start_markers.contains(&lane_key) {
-                        // This lane already has a start marker.
-                        // This marker is the end of that long note.
-                        // Skip it to prevent double-triggering.
                         ln_start_markers.remove(&lane_key);
                         continue;
                     }
                     if length.is_some() {
-                        // This lane has no start marker.
-                        // This marker is the start of a new long note.
-                        // Track it so we can skip the end marker when we encounter it.
                         ln_start_markers.insert(lane_key);
                     }
-                    // If length is None, this is an orphan end marker or zero-length note.
-                    // Skip it silently as it doesn't represent a valid playable note.
                 }
-
-                let evp = PlayheadEvent::new(id_gen.next_id(), *y, event, TimeSpan::ZERO);
-                events_map.entry(*y).or_default().push(evp);
+                self.push_event(*y, event);
             }
         }
+    }
 
-        for change in bms.bpm.bpm_changes.values() {
-            let y = get_event_y(change.time);
+    fn append_bpm_events(&mut self) {
+        for change in self.bms.bpm.bpm_changes.values() {
+            let y = (self.get_event_y)(change.time);
             let event = ChartEvent::BpmChange { bpm: change.bpm };
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
+            self.push_event(y, event);
         }
+    }
 
-        // Scroll change events
-        for change in bms.scroll.scrolling_factor_changes.values() {
-            let y = get_event_y(change.time);
+    fn append_scroll_events(&mut self) {
+        for change in self.bms.scroll.scrolling_factor_changes.values() {
+            let y = (self.get_event_y)(change.time);
             let event = ChartEvent::ScrollChange {
                 factor: change.factor,
             };
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
+            self.push_event(y, event);
         }
+    }
 
-        // Speed change events
-        for change in bms.speed.speed_factor_changes.values() {
-            let y = get_event_y(change.time);
+    fn append_speed_events(&mut self) {
+        for change in self.bms.speed.speed_factor_changes.values() {
+            let y = (self.get_event_y)(change.time);
             let event = ChartEvent::SpeedChange {
                 factor: change.factor,
             };
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
+            self.push_event(y, event);
         }
+    }
 
-        // Stop events
-        for stop in bms.stop.stops.values() {
-            let y = get_event_y(stop.time);
+    fn append_stop_events(&mut self) {
+        for stop in self.bms.stop.stops.values() {
+            let y = (self.get_event_y)(stop.time);
             let event = ChartEvent::Stop {
                 duration: convert_stop_duration_to_beats(stop.duration),
             };
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
+            self.push_event(y, event);
         }
+    }
 
-        // BGA change events
-        for bga_obj in bms.bmp.bga_changes.values() {
-            let y = get_event_y(bga_obj.time);
+    fn append_bga_events(&mut self) {
+        for bga_obj in self.bms.bmp.bga_changes.values() {
+            let y = (self.get_event_y)(bga_obj.time);
             let bmp_index = bga_obj.id.as_u16() as usize;
             let event = ChartEvent::BgaChange {
                 layer: bga_obj.layer,
                 bmp_id: Some(BmpId::from(bmp_index)),
             };
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
+            self.push_event(y, event);
         }
 
-        // BGA opacity change events (requires minor-command feature)
-
-        for (layer, opacity_changes) in &bms.bmp.bga_opacity_changes {
+        for (layer, opacity_changes) in &self.bms.bmp.bga_opacity_changes {
             for opacity_obj in opacity_changes.values() {
-                let y = get_event_y(opacity_obj.time);
+                let y = (self.get_event_y)(opacity_obj.time);
                 let event = ChartEvent::Bms(BmsEvent::BgaOpacityChange {
                     layer: *layer,
                     opacity: opacity_obj.opacity,
                 });
-                events_map.entry(y).or_default().push(PlayheadEvent::new(
-                    id_gen.next_id(),
-                    y,
-                    event,
-                    TimeSpan::ZERO,
-                ));
+                self.push_event(y, event);
             }
         }
 
-        // BGA ARGB color change events (requires minor-command feature)
-        for (layer, argb_changes) in &bms.bmp.bga_argb_changes {
+        for (layer, argb_changes) in &self.bms.bmp.bga_argb_changes {
             for argb_obj in argb_changes.values() {
-                let y = get_event_y(argb_obj.time);
+                let y = (self.get_event_y)(argb_obj.time);
                 let event = ChartEvent::Bms(BmsEvent::BgaArgbChange {
                     layer: *layer,
                     argb: argb_obj.argb,
                 });
-                events_map.entry(y).or_default().push(PlayheadEvent::new(
-                    id_gen.next_id(),
-                    y,
-                    event,
-                    TimeSpan::ZERO,
-                ));
+                self.push_event(y, event);
             }
         }
 
-        // BGM volume change events
-        for bgm_volume_obj in bms.volume.bgm_volume_changes.values() {
-            let y = get_event_y(bgm_volume_obj.time);
-            let event = ChartEvent::Bms(BmsEvent::BgmVolumeChange {
-                volume: bgm_volume_obj.volume,
-            });
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
-        }
-
-        // KEY volume change events
-        for key_volume_obj in bms.volume.key_volume_changes.values() {
-            let y = get_event_y(key_volume_obj.time);
-            let event = ChartEvent::Bms(BmsEvent::KeyVolumeChange {
-                volume: key_volume_obj.volume,
-            });
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
-        }
-
-        // Text display events
-        for text_obj in bms.text.text_events.values() {
-            let y = get_event_y(text_obj.time);
-            let event = ChartEvent::Bms(BmsEvent::TextDisplay {
-                text: text_obj.text.clone(),
-            });
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
-        }
-
-        // Judge level change events
-        for judge_obj in bms.judge.judge_events.values() {
-            let y = get_event_y(judge_obj.time);
-            let event = ChartEvent::Bms(BmsEvent::JudgeLevelChange {
-                level: judge_obj.judge_level,
-            });
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
-        }
-
-        for seek_obj in bms.video.seek_events.values() {
-            let y = get_event_y(seek_obj.time);
-            let event = ChartEvent::Bms(BmsEvent::VideoSeek {
-                seek_time: seek_obj.position.as_f64(),
-            });
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
-        }
-
-        for bga_keybound_obj in bms.bmp.bga_keybound_events.values() {
-            let y = get_event_y(bga_keybound_obj.time);
+        for bga_keybound_obj in self.bms.bmp.bga_keybound_events.values() {
+            let y = (self.get_event_y)(bga_keybound_obj.time);
             let event = ChartEvent::Bms(BmsEvent::BgaKeybound {
                 event: bga_keybound_obj.event.clone(),
             });
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
+            self.push_event(y, event);
         }
+    }
 
-        for option_obj in bms.option.option_events.values() {
-            let y = get_event_y(option_obj.time);
+    fn append_volume_events(&mut self) {
+        for bgm_volume_obj in self.bms.volume.bgm_volume_changes.values() {
+            let y = (self.get_event_y)(bgm_volume_obj.time);
+            let event = ChartEvent::Bms(BmsEvent::BgmVolumeChange {
+                volume: bgm_volume_obj.volume,
+            });
+            self.push_event(y, event);
+        }
+        for key_volume_obj in self.bms.volume.key_volume_changes.values() {
+            let y = (self.get_event_y)(key_volume_obj.time);
+            let event = ChartEvent::Bms(BmsEvent::KeyVolumeChange {
+                volume: key_volume_obj.volume,
+            });
+            self.push_event(y, event);
+        }
+    }
+
+    fn append_text_events(&mut self) {
+        for text_obj in self.bms.text.text_events.values() {
+            let y = (self.get_event_y)(text_obj.time);
+            let event = ChartEvent::Bms(BmsEvent::TextDisplay {
+                text: text_obj.text.clone(),
+            });
+            self.push_event(y, event);
+        }
+    }
+
+    fn append_judge_events(&mut self) {
+        for judge_obj in self.bms.judge.judge_events.values() {
+            let y = (self.get_event_y)(judge_obj.time);
+            let event = ChartEvent::Bms(BmsEvent::JudgeLevelChange {
+                level: judge_obj.judge_level,
+            });
+            self.push_event(y, event);
+        }
+    }
+
+    fn append_video_events(&mut self) {
+        for seek_obj in self.bms.video.seek_events.values() {
+            let y = (self.get_event_y)(seek_obj.time);
+            let event = ChartEvent::Bms(BmsEvent::VideoSeek {
+                seek_time: seek_obj.position.as_f64(),
+            });
+            self.push_event(y, event);
+        }
+    }
+
+    fn append_option_events(&mut self) {
+        for option_obj in self.bms.option.option_events.values() {
+            let y = (self.get_event_y)(option_obj.time);
             let event = ChartEvent::Bms(BmsEvent::OptionChange {
                 option: option_obj.option.clone(),
             });
-            events_map.entry(y).or_default().push(PlayheadEvent::new(
-                id_gen.next_id(),
-                y,
-                event,
-                TimeSpan::ZERO,
-            ));
+            self.push_event(y, event);
         }
-
-        BmsProcessor::generate_barlines_for_bms(bms, y_memo, &mut events_map, &mut id_gen);
-        Self::new(events_map)
     }
 }
 
@@ -769,7 +696,7 @@ pub fn precompute_activate_times(
 /// - `ChartEvent::Note` for playable notes
 /// - `ChartEvent::Bgm` for BGM/background audio
 #[must_use]
-pub fn event_for_note_static<T: KeyLayoutMapper>(
+pub fn event_for_note_static<T: BmsLayoutMapper>(
     bms: &Bms,
     y_memo: &YMemo,
     obj: &WavObj,
@@ -804,15 +731,15 @@ impl TryFrom<Bms> for Chart {
     type Error = PlayingError;
 
     fn try_from(bms: Bms) -> Result<Self, Self::Error> {
-        BmsProcessor::parse::<crate::bms::command::channel::mapper::KeyLayoutBeat>(&bms)
+        bms.process()
     }
 }
 
 impl Process for Bms {
     type Error = PlayingError;
 
-    fn process(self) -> Result<Chart, Self::Error> {
-        BmsProcessor::parse::<crate::bms::command::channel::mapper::KeyLayoutBeat>(&self)
+    fn process(&self) -> Result<Chart, Self::Error> {
+        BmsProcessor::parse::<crate::bms::command::channel::mapper::BmsLayoutBeat>(self)
     }
 }
 
@@ -865,7 +792,7 @@ impl BaseBpmGenerator<Bms> for crate::chart::player::base_bpm::ManualBpmGenerato
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bms::command::channel::mapper::KeyLayoutBeat;
+    use crate::bms::command::channel::mapper::BmsLayoutBeat;
     use crate::bms::command::string_value::StringValue;
 
     /// Test that parsing fails when BPM value is invalid (non-numeric string)
@@ -876,7 +803,7 @@ mod tests {
         bms.bpm.bpm = Some(StringValue::new("invalid_bpm"));
 
         // Try to parse, should return InvalidBpm error
-        let result = BmsProcessor::parse::<KeyLayoutBeat>(&bms);
+        let result = BmsProcessor::parse::<BmsLayoutBeat>(&bms);
 
         assert!(result.is_err());
         match result {
@@ -895,7 +822,7 @@ mod tests {
         let mut bms = Bms::default();
         bms.bpm.bpm = Some(StringValue::new(""));
 
-        let result = BmsProcessor::parse::<KeyLayoutBeat>(&bms);
+        let result = BmsProcessor::parse::<BmsLayoutBeat>(&bms);
 
         assert!(result.is_err());
         match result {
@@ -912,7 +839,7 @@ mod tests {
         let mut bms = Bms::default();
         bms.bpm.bpm = Some(StringValue::new("NaN"));
 
-        let result = BmsProcessor::parse::<KeyLayoutBeat>(&bms);
+        let result = BmsProcessor::parse::<BmsLayoutBeat>(&bms);
 
         assert!(result.is_err());
         match result {
@@ -930,7 +857,7 @@ mod tests {
         let bms = Bms::default();
 
         // Parse should succeed with default BPM (120)
-        let result = BmsProcessor::parse::<KeyLayoutBeat>(&bms);
+        let result = BmsProcessor::parse::<BmsLayoutBeat>(&bms);
 
         assert!(
             result.is_ok(),
@@ -948,7 +875,7 @@ mod tests {
         let mut bms = Bms::default();
         bms.bpm.bpm = Some(StringValue::new("150.5"));
 
-        let result = BmsProcessor::parse::<KeyLayoutBeat>(&bms);
+        let result = BmsProcessor::parse::<BmsLayoutBeat>(&bms);
 
         assert!(
             result.is_ok(),
@@ -964,7 +891,7 @@ mod tests {
         let mut bms = Bms::default();
         bms.bpm.bpm = Some(StringValue::new("abc123!@#"));
 
-        let result = BmsProcessor::parse::<KeyLayoutBeat>(&bms);
+        let result = BmsProcessor::parse::<BmsLayoutBeat>(&bms);
 
         assert!(result.is_err());
         match result {
@@ -984,7 +911,7 @@ mod tests {
         let mut bms = Bms::default();
         bms.bpm.bpm = Some(StringValue::new(invalid_value));
 
-        let result = BmsProcessor::parse::<KeyLayoutBeat>(&bms);
+        let result = BmsProcessor::parse::<BmsLayoutBeat>(&bms);
 
         match result {
             Err(PlayingError::InvalidBpm { raw, .. }) => {

--- a/src/bms/unparse.rs
+++ b/src/bms/unparse.rs
@@ -10,13 +10,16 @@ use crate::{
     chart::types::{Argb, BgaLayer},
 };
 
+// ---- Private helpers on Bms for unparsing ----
+
 impl Bms {
     /// Convert Bms to `Vec<Token>` (in conventional order: header -> definitions -> resources -> messages).
     /// - Avoid duplicate parsing: directly construct Tokens using model data;
     /// - For messages requiring `ObjId`, prioritize reusing existing definitions; if missing, allocate new `ObjId` and add definition Token (only reflected in returned Token list).
+    /// - Channel IDs are preserved as-is; no key layout mapping is applied.
     #[must_use]
-    pub fn unparse<'a, T: KeyLayoutMapper>(&'a self) -> Vec<Token<'a>> {
-        let mut tokens: Vec<Token<'a>> = Vec::new();
+    pub fn unparse(&self) -> Vec<Token<'_>> {
+        let mut tokens: Vec<Token<'_>> = Vec::new();
 
         // Others section lines FIRST to preserve order equality on roundtrip
         self.unparse_headers(&mut tokens);
@@ -24,7 +27,7 @@ impl Bms {
         // Check if any of the used IDs require base62 (not base36 but valid base62)
         let mut base62_checker = Base62Checker::new();
 
-        self.unparse_messages::<T>(&mut tokens, &mut base62_checker);
+        Self::unparse_messages(self, &mut tokens, &mut base62_checker);
 
         // Add ObjIds from definition tokens that are not covered by managers
         // ExWav definitions
@@ -74,6 +77,917 @@ impl Bms {
         tokens
     }
 
+    fn unparse_messages<'a>(
+        bms: &'a Bms,
+        tokens: &mut Vec<Token<'a>>,
+        checker: &mut Base62Checker,
+    ) {
+        // Collect late definition tokens and message tokens
+        let mut late_def_tokens: Vec<Token<'a>> = Vec::new();
+        let mut message_tokens: Vec<Token<'a>> = Vec::new();
+
+        // Messages: Section length - Use iterator chain to collect tokens (sorted by track for consistent output)
+        let mut section_len_tokens: Vec<_> = bms
+            .section_len
+            .section_len_changes
+            .values()
+            .map(|obj| Token::Message {
+                track: obj.track,
+                channel: Channel::SectionLen,
+                message: Cow::Owned(obj.length.to_string()),
+            })
+            .collect();
+        section_len_tokens.sort_by_key(|token| match token {
+            Token::Message { track, .. } => *track,
+            _ => Track(0),
+        });
+        message_tokens.extend(section_len_tokens);
+
+        // Helper closures for mapping definitions
+        // Note: We use f64::to_bits() as key since FinF64 doesn't implement Hash
+
+        let bpm_value_to_id: HashMap<u64, ObjId> = bms
+            .bpm
+            .bpm_defs
+            .iter()
+            .filter_map(|(k, v)| {
+                v.value()
+                    .as_ref()
+                    .ok()
+                    .map(|val| (val.as_f64().to_bits(), *k))
+            })
+            .collect();
+        let stop_value_to_id: HashMap<u64, ObjId> = bms
+            .stop
+            .stop_defs
+            .iter()
+            .filter_map(|(k, v)| {
+                v.value()
+                    .as_ref()
+                    .ok()
+                    .map(|val| (val.as_f64().to_bits(), *k))
+            })
+            .collect();
+        let scroll_value_to_id: HashMap<u64, ObjId> = bms
+            .scroll
+            .scroll_defs
+            .iter()
+            .filter_map(|(k, v)| {
+                v.value()
+                    .as_ref()
+                    .ok()
+                    .map(|val| (val.as_f64().to_bits(), *k))
+            })
+            .collect();
+        let speed_value_to_id: HashMap<u64, ObjId> = bms
+            .speed
+            .speed_defs
+            .iter()
+            .filter_map(|(k, v)| {
+                v.value()
+                    .as_ref()
+                    .ok()
+                    .map(|val| (val.as_f64().to_bits(), *k))
+            })
+            .collect();
+        let text_value_to_id: HashMap<&'a str, ObjId> = bms
+            .text
+            .texts
+            .iter()
+            .map(|(k, v)| (v.as_str(), *k))
+            .collect();
+        let exrank_value_to_id: HashMap<&'a JudgeLevel, ObjId> = bms
+            .judge
+            .exrank_defs
+            .iter()
+            .map(|(k, v)| (&v.judge_level, *k))
+            .collect();
+
+        let seek_value_to_id: HashMap<u64, ObjId> = bms
+            .video
+            .seek_defs
+            .iter()
+            .filter_map(|(k, v)| {
+                v.value()
+                    .as_ref()
+                    .ok()
+                    .map(|val| (val.as_f64().to_bits(), *k))
+            })
+            .collect();
+
+        // Messages: BPM change (#xxx08 or #xxx03)
+        let mut bpm_message_tokens = Vec::new();
+
+        // Process U8 type BPM changes
+        let EventProcessingResult {
+            message_tokens: bpm_u8_message_tokens,
+            ..
+        } = build_event_messages(
+            bms.bpm.bpm_changes_u8.iter(),
+            None::<(
+                fn(ObjId, &()) -> Token,
+                fn(&_) -> &(),
+                &mut ObjIdManager<()>,
+            )>,
+            |_ev| Channel::BpmChangeU8,
+            |bpm, _id| {
+                let s = format!("{bpm:02X}");
+                let mut chars = s.chars();
+                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+            },
+        );
+        bpm_message_tokens.extend(bpm_u8_message_tokens);
+
+        // Process other type BPM changes using build_event_messages_owned
+        let mut bpm_manager: HashMap<u64, ObjId> = bpm_value_to_id;
+        let EventProcessingResult {
+            late_def_tokens: other_late_def_tokens,
+            message_tokens: other_message_tokens,
+        } = build_event_messages_owned(
+            bms.bpm.bpm_changes.iter(),
+            Some((
+                |id, bpm_bits: &u64| Token::Header {
+                    name: format!("BPM{id}").into(),
+                    args: f64::from_bits(*bpm_bits).to_string().into(),
+                },
+                |ev: &'a BpmChangeObj| ev.bpm.as_f64().to_bits(),
+                &mut bpm_manager,
+            )),
+            |_ev| Channel::BpmChange,
+            |_ev, id| {
+                let id = id.unwrap_or(ObjId::null());
+                id.into_chars()
+            },
+        );
+
+        // Update id_manager with the results
+        late_def_tokens.extend(other_late_def_tokens);
+        bpm_message_tokens.extend(other_message_tokens);
+
+        message_tokens.extend(bpm_message_tokens);
+
+        // Messages: STOP (#xxx09)
+        let mut stop_manager: HashMap<u64, ObjId> = stop_value_to_id;
+        let EventProcessingResult {
+            late_def_tokens: stop_late_def_tokens,
+            message_tokens: stop_message_tokens,
+        } = build_event_messages_owned(
+            bms.stop.stops.iter(),
+            Some((
+                |id, duration_bits: &u64| Token::Header {
+                    name: format!("STOP{id}").into(),
+                    args: f64::from_bits(*duration_bits).to_string().into(),
+                },
+                |ev: &'a StopObj| ev.duration.as_f64().to_bits(),
+                &mut stop_manager,
+            )),
+            |_ev| Channel::Stop,
+            |_ev, id| {
+                let id = id.unwrap_or(ObjId::null());
+                id.into_chars()
+            },
+        );
+        late_def_tokens.extend(stop_late_def_tokens);
+        message_tokens.extend(stop_message_tokens);
+
+        // Messages: SCROLL (#xxxSC)
+        let mut scroll_manager: HashMap<u64, ObjId> = scroll_value_to_id;
+        let EventProcessingResult {
+            late_def_tokens: scroll_late_def_tokens,
+            message_tokens: scroll_message_tokens,
+        } = build_event_messages_owned(
+            bms.scroll.scrolling_factor_changes.iter(),
+            Some((
+                |id, factor_bits: &u64| Token::Header {
+                    name: format!("SCROLL{id}").into(),
+                    args: f64::from_bits(*factor_bits).to_string().into(),
+                },
+                |ev: &'a ScrollingFactorObj| ev.factor.as_f64().to_bits(),
+                &mut scroll_manager,
+            )),
+            |_ev| Channel::Scroll,
+            |_ev, id| {
+                let id = id.unwrap_or(ObjId::null());
+                id.into_chars()
+            },
+        );
+        late_def_tokens.extend(scroll_late_def_tokens);
+        message_tokens.extend(scroll_message_tokens);
+
+        // Messages: SPEED (#xxxSP)
+        let mut speed_manager: HashMap<u64, ObjId> = speed_value_to_id;
+        let EventProcessingResult {
+            late_def_tokens: speed_late_def_tokens,
+            message_tokens: speed_message_tokens,
+        } = build_event_messages_owned(
+            bms.speed.speed_factor_changes.iter(),
+            Some((
+                |id, factor_bits: &u64| Token::Header {
+                    name: format!("SPEED{id}").into(),
+                    args: f64::from_bits(*factor_bits).to_string().into(),
+                },
+                |ev: &'a SpeedObj| ev.factor.as_f64().to_bits(),
+                &mut speed_manager,
+            )),
+            |_ev| Channel::Speed,
+            |_ev, id| {
+                let id = id.unwrap_or(ObjId::null());
+                id.into_chars()
+            },
+        );
+        late_def_tokens.extend(speed_late_def_tokens);
+        message_tokens.extend(speed_message_tokens);
+
+        {
+            // STP events, sorted by time for consistent output
+            let mut stp_events: Vec<_> = bms.stop.stp_events.values().collect();
+            stp_events.sort_by_key(|ev| ev.time);
+            tokens.extend(stp_events.into_iter().map(|ev| {
+                Token::Header {
+                    name: "STP".into(),
+                    args: format!(
+                        "{:03}.{:03} {}",
+                        ev.time.track(),
+                        ev.time.numerator() * ev.time.denominator_u64() / 1000,
+                        ev.duration.as_millis()
+                    )
+                    .into(),
+                }
+            }));
+        }
+
+        // Messages: BGA changes (#xxx04/#xxx07/#xxx06/#xxx0A)
+        let EventProcessingResult {
+            message_tokens: bga_message_tokens,
+            ..
+        } = build_event_messages(
+            bms.bmp.bga_changes.iter(),
+            None::<(
+                fn(ObjId, &'a ()) -> Token<'a>,
+                fn(&_) -> &'a (),
+                &mut ObjIdManager<()>,
+            )>,
+            |bga| bga.layer.to_channel(),
+            |bga, _id| {
+                let s = bga.id.to_string();
+                let mut chars = s.chars();
+                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+            },
+        );
+        message_tokens.extend(bga_message_tokens);
+
+        {
+            // Messages: BGA opacity changes (#xxx0B/#xxx0C/#xxx0D/#xxx0E)
+            for (layer, opacity_changes) in &bms.bmp.bga_opacity_changes {
+                let EventProcessingResult {
+                    message_tokens: opacity_message_tokens,
+                    ..
+                } = build_event_messages(
+                    opacity_changes.iter(),
+                    None::<(
+                        fn(ObjId, &'a ()) -> Token<'a>,
+                        fn(&_) -> &'a (),
+                        &mut ObjIdManager<()>,
+                    )>,
+                    |_ev| match layer {
+                        BgaLayer::Base => Channel::BgaBaseOpacity,
+                        BgaLayer::Poor => Channel::BgaPoorOpacity,
+                        BgaLayer::Overlay => Channel::BgaLayerOpacity,
+                        BgaLayer::Overlay2 => Channel::BgaLayer2Opacity,
+                    },
+                    |ev, _id| {
+                        let s = format!("{:02X}", ev.opacity);
+                        let mut chars = s.chars();
+                        [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+                    },
+                );
+                message_tokens.extend(opacity_message_tokens);
+            }
+
+            // Messages: BGA ARGB changes (#xxxA1/#xxxA2/#xxxA3/#xxxA4)
+            for (layer, argb_changes) in &bms.bmp.bga_argb_changes {
+                let EventProcessingResult {
+                    message_tokens: argb_message_tokens,
+                    ..
+                } = build_event_messages(
+                    argb_changes.iter(),
+                    None::<(
+                        fn(ObjId, &'a ()) -> Token<'a>,
+                        fn(&_) -> &'a (),
+                        &mut ObjIdManager<()>,
+                    )>,
+                    |_ev| match layer {
+                        BgaLayer::Base => Channel::BgaBaseArgb,
+                        BgaLayer::Poor => Channel::BgaPoorArgb,
+                        BgaLayer::Overlay => Channel::BgaLayerArgb,
+                        BgaLayer::Overlay2 => Channel::BgaLayer2Argb,
+                    },
+                    |ev, _id| {
+                        let s = format!("{:02X}", ev.argb.alpha);
+                        let mut chars = s.chars();
+                        [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+                    },
+                );
+                message_tokens.extend(argb_message_tokens);
+            }
+        }
+
+        // Messages: BGM (#xxx01) and Notes (various #xx)
+        // Use build_event_messages to process note and BGM objects
+        // We need to preserve the original insertion order, so we process each object individually
+        let EventProcessingResult {
+            message_tokens: notes_message_tokens,
+            ..
+        } = build_event_messages(
+            bms.wav
+                .notes
+                .all_notes_insertion_order()
+                .map(|obj| (&obj.offset, obj)),
+            None::<(
+                fn(ObjId, &()) -> Token,
+                fn(&_) -> &(),
+                &mut ObjIdManager<()>,
+            )>,
+            |obj| {
+                if obj.channel_id.is_bgm() {
+                    Channel::Bgm
+                } else {
+                    Channel::Note {
+                        channel_id: obj.channel_id,
+                    }
+                }
+            },
+            |obj, _id| {
+                let s = obj.wav_id.to_string();
+                let mut chars = s.chars();
+                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+            }, // Message formatting: use wav_id
+        );
+
+        message_tokens.extend(notes_message_tokens);
+
+        // Messages: BGM volume (#97)
+        let EventProcessingResult {
+            message_tokens: bgm_volume_message_tokens,
+            ..
+        } = build_event_messages(
+            bms.volume.bgm_volume_changes.iter(),
+            None::<(
+                fn(ObjId, &'a ()) -> Token<'a>,
+                fn(&_) -> &'a (),
+                &mut ObjIdManager<()>,
+            )>,
+            |_ev| Channel::BgmVolume,
+            |ev, _id| {
+                let s = format!("{:02X}", ev.volume);
+                let mut chars = s.chars();
+                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+            },
+        );
+        message_tokens.extend(bgm_volume_message_tokens);
+
+        // Messages: KEY volume (#98)
+        let EventProcessingResult {
+            message_tokens: key_volume_message_tokens,
+            ..
+        } = build_event_messages(
+            bms.volume.key_volume_changes.iter(),
+            None::<(
+                fn(ObjId, &'a ()) -> Token<'a>,
+                fn(&_) -> &'a (),
+                &mut ObjIdManager<()>,
+            )>,
+            |_ev| Channel::KeyVolume,
+            |ev, _id| {
+                let s = format!("{:02X}", ev.volume);
+                let mut chars = s.chars();
+                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+            },
+        );
+        message_tokens.extend(key_volume_message_tokens);
+
+        // Messages: TEXT (#99)
+        let mut text_manager =
+            ObjIdManager::from_entries(text_value_to_id.iter().map(|(k, v)| (*k, *v)));
+        let EventProcessingResult {
+            late_def_tokens: text_late_def_tokens,
+            message_tokens: text_message_tokens,
+        } = build_event_messages(
+            bms.text.text_events.iter(),
+            Some((
+                |id, text: &'a str| Token::Header {
+                    name: format!("TEXT{id}").into(),
+                    args: text.into(),
+                },
+                |ev: &'a TextObj| ev.text.as_str(),
+                &mut text_manager,
+            )),
+            |_ev| Channel::Text,
+            |_ev, id| {
+                let id = id.unwrap_or(ObjId::null());
+                id.into_chars()
+            },
+        );
+        checker.check(text_manager.into_assigned_ids());
+        late_def_tokens.extend(text_late_def_tokens);
+        message_tokens.extend(text_message_tokens);
+
+        let mut exrank_manager =
+            ObjIdManager::from_entries(exrank_value_to_id.iter().map(|(k, v)| (*k, *v)));
+        let EventProcessingResult {
+            late_def_tokens: judge_late_def_tokens,
+            message_tokens: judge_message_tokens,
+        } = build_event_messages(
+            bms.judge.judge_events.iter(),
+            Some((
+                |id, judge_level: &JudgeLevel| Token::Header {
+                    name: format!("EXRANK{id}").into(),
+                    args: judge_level.to_string().into(),
+                },
+                |ev: &'a JudgeObj| &ev.judge_level,
+                &mut exrank_manager,
+            )),
+            |_ev| Channel::Judge,
+            |_ev, id| {
+                let id = id.unwrap_or(ObjId::null());
+                id.into_chars()
+            },
+        );
+        checker.check(exrank_manager.into_assigned_ids());
+        late_def_tokens.extend(judge_late_def_tokens);
+        message_tokens.extend(judge_message_tokens);
+
+        if let Some(poor_bmp) = bms.bmp.poor_bmp.as_ref()
+            && !poor_bmp.as_path().as_os_str().is_empty()
+        {
+            tokens.push(Token::Header {
+                name: "BMP00".into(),
+                args: poor_bmp.display().to_string().into(),
+            });
+        }
+
+        tokens.extend(
+            bms.bmp
+                .bmp_files
+                .iter()
+                .filter(|(_, bmp)| !bmp.file.as_path().as_os_str().is_empty())
+                .map(|(id, bmp)| {
+                    (
+                        *id,
+                        if bmp.transparent_color == Argb::default() {
+                            Token::Header {
+                                name: format!("BMP{id}").into(),
+                                args: bmp.file.display().to_string().into(),
+                            }
+                        } else {
+                            Token::Header {
+                                name: format!("EXBMP{id}").into(),
+                                args: format!(
+                                    "{},{},{},{} {}",
+                                    bmp.transparent_color.alpha,
+                                    bmp.transparent_color.red,
+                                    bmp.transparent_color.green,
+                                    bmp.transparent_color.blue,
+                                    bmp.file.display()
+                                )
+                                .into(),
+                            }
+                        },
+                    )
+                })
+                .collect::<BTreeMap<_, _>>()
+                .into_values(),
+        );
+
+        {
+            // Messages: SEEK (#xxx05)
+            let mut seek_manager: HashMap<u64, ObjId> = seek_value_to_id;
+            let EventProcessingResult {
+                late_def_tokens: seek_late_def_tokens,
+                message_tokens: seek_message_tokens,
+            } = build_event_messages_owned(
+                bms.video.seek_events.iter(),
+                Some((
+                    |id, position_bits: &u64| Token::Header {
+                        name: format!("SEEK{id}").into(),
+                        args: f64::from_bits(*position_bits).to_string().into(),
+                    },
+                    |ev: &'a SeekObj| ev.position.as_f64().to_bits(),
+                    &mut seek_manager,
+                )),
+                |_ev| Channel::Seek,
+                |_ev, id| {
+                    let id = id.unwrap_or(ObjId::null());
+                    let s = id.to_string();
+                    let mut chars = s.chars();
+                    [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+                },
+            );
+            late_def_tokens.extend(seek_late_def_tokens);
+            message_tokens.extend(seek_message_tokens);
+
+            // Messages: BGA keybound (#xxxA5)
+            let EventProcessingResult {
+                message_tokens: bga_keybound_message_tokens,
+                ..
+            } = build_event_messages(
+                bms.bmp.bga_keybound_events.iter(),
+                None::<(
+                    fn(ObjId, &'a ()) -> Token<'a>,
+                    fn(&_) -> &'a (),
+                    &mut ObjIdManager<()>,
+                )>,
+                |_ev| Channel::BgaKeybound,
+                |ev, _id| {
+                    let s = format!("{:02X}", ev.event.line);
+                    let mut chars = s.chars();
+                    [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+                },
+            );
+            message_tokens.extend(bga_keybound_message_tokens);
+
+            // Messages: OPTION (#xxxA6)
+            let EventProcessingResult {
+                message_tokens: option_message_tokens,
+                ..
+            } = build_event_messages(
+                bms.option.option_events.iter(),
+                None::<(
+                    fn(ObjId, &'a ()) -> Token<'a>,
+                    fn(&_) -> &'a (),
+                    &mut ObjIdManager<()>,
+                )>,
+                |_ev| Channel::OptionChange,
+                |_ev, _id| {
+                    let s = format!("{:02X}", 0);
+                    let mut chars = s.chars();
+                    [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
+                }, // Option events don't use values
+            );
+            checker.check(seek_manager.values().copied());
+            message_tokens.extend(option_message_tokens);
+        };
+
+        // Assembly: header/definitions/resources/others -> late definitions -> messages
+        if !late_def_tokens.is_empty() {
+            tokens.extend(late_def_tokens);
+        }
+        if !message_tokens.is_empty() {
+            tokens.extend(message_tokens);
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Base62Checker {
+    using_base62: bool,
+}
+
+impl Base62Checker {
+    const fn new() -> Self {
+        Self {
+            using_base62: false,
+        }
+    }
+
+    fn check(&mut self, iter: impl IntoIterator<Item = ObjId>) {
+        if !self.using_base62 && iter.into_iter().any(|id| !id.is_base36() && id.is_base62()) {
+            self.using_base62 = true;
+        }
+    }
+
+    const fn into_using_base62(self) -> bool {
+        self.using_base62
+    }
+}
+
+/// A unit of event processing containing all necessary information for token generation
+#[derive(Debug, Clone)]
+struct EventUnit<'a, Event> {
+    time: ObjTime,
+    event: &'a Event,
+    channel: Channel,
+    id: Option<ObjId>,
+}
+
+/// Complete result from `build_messages_event` containing all processing outputs
+struct EventProcessingResult<'a> {
+    message_tokens: Vec<Token<'a>>,
+    late_def_tokens: Vec<Token<'a>>,
+}
+
+/// Generic function to process message types with optional ID allocation
+///
+/// This function processes time-indexed events from an iterator and converts them into message tokens.
+/// It supports both ID allocation mode (using `token_creator` and `key_extractor`) and direct mode (without ID allocation).
+///
+/// # PROCESSING FLOW OVERVIEW:
+/// 1. **GROUP EVENTS**: Events are grouped by track, channel, and non-strictly increasing time
+/// 2. **SPLIT INTO MESSAGE SEGMENTS**: Each group is further split into message segments with stricter rules:
+///    - Strictly increasing time (prevents overlaps)
+///    - Consistent denominators (ensures accurate representation)
+/// 3. **GENERATE TOKENS**: Each message segment becomes one `Token::Message` with all events encoded
+///
+/// Arguments:
+///     events: An iterator yielding (&time, &event) pairs to process
+///     `id_allocation`: Optional tuple containing (`token_creator`, `key_extractor`, `id_manager`) for ID allocation mode
+///     `channel_mapper`: Function to map events to channels
+///     `message_formatter`: Function to format events into [char; 2]
+///
+/// Returns:
+///     `EventProcessingResult` containing `message_tokens`, `late_def_tokens`, and updated maps
+///
+/// The function leverages Rust's iterator chains for efficient processing and supports
+/// both ID-based and direct value-based event processing.
+/// Common pipeline: convert processed `EventUnit`s into message tokens.
+/// Steps: group by track/channel/time → split into message segments → tokenize.
+fn run_message_pipeline<'a, Event>(
+    processed_events: Vec<EventUnit<'a, Event>>,
+    message_formatter: &impl Fn(&'a Event, Option<ObjId>) -> [char; 2],
+) -> Vec<Token<'a>> {
+    let grouped_events = group_events_by_track_channel_time(processed_events);
+    let message_segmented_events: Vec<Vec<_>> = grouped_events
+        .into_iter()
+        .flat_map(split_group_into_message_segments)
+        .collect();
+    message_segmented_events
+        .into_iter()
+        .map(|segment| convert_message_segment_to_token(segment, message_formatter))
+        .collect()
+}
+
+fn build_event_messages<
+    'a,
+    Event: 'a,
+    Key: 'a + ?Sized + std::hash::Hash + Eq,
+    EventIterator,
+    TokenCreator,
+    KeyExtractor,
+    ChannelMapper,
+    MessageFormatter,
+>(
+    event_iter: EventIterator,
+    mut id_allocation: Option<(TokenCreator, KeyExtractor, &mut ObjIdManager<'a, Key>)>,
+    channel_mapper: ChannelMapper,
+    message_formatter: MessageFormatter,
+) -> EventProcessingResult<'a>
+where
+    EventIterator: Iterator<Item = (&'a ObjTime, &'a Event)>,
+    TokenCreator: Fn(ObjId, &'a Key) -> Token<'a>,
+    KeyExtractor: Fn(&'a Event) -> &'a Key,
+    ChannelMapper: Fn(&'a Event) -> Channel,
+    MessageFormatter: Fn(&'a Event, Option<ObjId>) -> [char; 2],
+{
+    let mut late_def_tokens: Vec<Token<'a>> = Vec::new();
+
+    // Process events based on whether id_allocation tuple is provided
+    // Keep original order from event_iter instead of grouping by track/channel
+    let processed_events: Vec<EventUnit<'a, Event>> = event_iter
+        .map(|(&time, event)| {
+            let id = id_allocation
+                .as_mut()
+                .and_then(|(token_creator, key_extractor, manager)| {
+                    let key = key_extractor(event);
+                    let is_assigned = manager.is_assigned(key);
+                    let id = manager.get_or_new_id(key);
+                    if !is_assigned && let Some(new) = id {
+                        late_def_tokens.push(token_creator(new, key));
+                    }
+                    id
+                });
+            EventUnit {
+                time,
+                event,
+                channel: channel_mapper(event),
+                id,
+            }
+        })
+        .collect();
+
+    let message_tokens = run_message_pipeline(processed_events, &message_formatter);
+
+    EventProcessingResult {
+        message_tokens,
+        late_def_tokens,
+    }
+}
+
+/// A version of `build_event_messages` that supports owned keys (like u64 instead of &u64)
+fn build_event_messages_owned<
+    'a,
+    Event: 'a,
+    Key: std::hash::Hash + Eq + Clone,
+    EventIterator,
+    TokenCreator,
+    KeyExtractor,
+    ChannelMapper,
+    MessageFormatter,
+>(
+    event_iter: EventIterator,
+    mut id_allocation: Option<(TokenCreator, KeyExtractor, &mut HashMap<Key, ObjId>)>,
+    channel_mapper: ChannelMapper,
+    message_formatter: MessageFormatter,
+) -> EventProcessingResult<'a>
+where
+    EventIterator: Iterator<Item = (&'a ObjTime, &'a Event)>,
+    TokenCreator: Fn(ObjId, &Key) -> Token<'a>,
+    KeyExtractor: Fn(&'a Event) -> Key,
+    ChannelMapper: Fn(&'a Event) -> Channel,
+    MessageFormatter: Fn(&'a Event, Option<ObjId>) -> [char; 2],
+{
+    let mut late_def_tokens: Vec<Token<'a>> = Vec::new();
+
+    // Process events based on whether id_allocation tuple is provided
+    let processed_events: Vec<EventUnit<'a, Event>> = event_iter
+        .map(|(&time, event)| {
+            let id = id_allocation
+                .as_mut()
+                .and_then(|(token_creator, key_extractor, manager)| {
+                    let key = key_extractor(event);
+                    let _is_assigned = manager.contains_key(&key);
+
+                    manager.get(&key).copied().or_else(|| {
+                        let new_id =
+                            ObjId::all_values().find(|id| !manager.values().any(|&v| v == *id));
+                        if let Some(new_id) = new_id {
+                            manager.insert(key.clone(), new_id);
+                            late_def_tokens.push(token_creator(new_id, &key));
+                        }
+                        new_id
+                    })
+                });
+            EventUnit {
+                time,
+                event,
+                channel: channel_mapper(event),
+                id,
+            }
+        })
+        .collect();
+
+    let message_tokens = run_message_pipeline(processed_events, &message_formatter);
+
+    EventProcessingResult {
+        message_tokens,
+        late_def_tokens,
+    }
+}
+
+/// Group events by track, channel, and non-strictly increasing time
+fn group_events_by_track_channel_time<'a, Event>(
+    processed_events: Vec<EventUnit<'a, Event>>,
+) -> Vec<Vec<EventUnit<'a, Event>>> {
+    let mut groups = Vec::new();
+    let mut current_group = Vec::new();
+
+    for event_unit in processed_events {
+        let should_join = current_group
+            .last()
+            .is_some_and(|last_unit: &EventUnit<'a, Event>| {
+                event_unit.time.track() == last_unit.time.track()
+                    && last_unit.channel == event_unit.channel
+                    && last_unit.time <= event_unit.time
+            });
+
+        if should_join {
+            current_group.push(event_unit);
+        } else {
+            if !current_group.is_empty() {
+                groups.push(current_group);
+            }
+            current_group = vec![event_unit];
+        }
+    }
+
+    if !current_group.is_empty() {
+        groups.push(current_group);
+    }
+    groups
+}
+
+/// Split a group into message segments based on time ordering and denominator consistency
+fn split_group_into_message_segments<'a, Event>(
+    group: Vec<EventUnit<'a, Event>>,
+) -> Vec<Vec<EventUnit<'a, Event>>> {
+    let mut message_segments = Vec::new();
+    let mut current_message_segment = Vec::new();
+
+    for event_unit in group {
+        let should_join =
+            current_message_segment
+                .last()
+                .is_none_or(|last_unit: &EventUnit<'a, Event>| {
+                    // MESSAGE SEGMENT JOINING RULES:
+                    // 1. Time must be strictly increasing (prevents overlapping events)
+                    // 2. Denominators must be compatible:
+                    //    - If current message segment is empty, accept any denominator
+                    //    - Otherwise, denominators must share a factor relationship (either is a factor of the other)
+                    //    - Reference denominator is the maximum denominator currently in the message segment
+                    (last_unit.time < event_unit.time)
+                        && (current_message_segment.is_empty()
+                            || is_denominator_compatible(&event_unit, &current_message_segment))
+                }); // Empty message segment always accepts the first event
+
+        if should_join {
+            current_message_segment.push(event_unit);
+        } else {
+            if !current_message_segment.is_empty() {
+                message_segments.push(current_message_segment);
+            }
+            current_message_segment = vec![event_unit];
+        }
+    }
+
+    if !current_message_segment.is_empty() {
+        message_segments.push(current_message_segment);
+    }
+    message_segments
+}
+
+/// Check if an event unit's denominator is compatible with the current message segment
+/// Two denominators are compatible if either is a factor of the other
+fn is_denominator_compatible<'a, Event>(
+    event_unit: &EventUnit<'a, Event>,
+    message_segment: &[EventUnit<'a, Event>],
+) -> bool {
+    // Find the maximum denominator from the current message segment as reference
+    let reference_denominator = message_segment
+        .iter()
+        .map(|unit| unit.time.denominator_u64())
+        .max()
+        .unwrap_or(1);
+
+    // Check if the event unit's denominator shares a common factor relationship
+    let event_denominator = event_unit.time.denominator_u64();
+    reference_denominator.is_multiple_of(event_denominator)
+        || event_denominator.is_multiple_of(reference_denominator)
+}
+
+/// Convert a message segment of events into a single `Token::Message`
+fn convert_message_segment_to_token<'a, Event, MessageFormatter>(
+    message_segment: Vec<EventUnit<'a, Event>>,
+    message_formatter: &MessageFormatter,
+) -> Token<'a>
+where
+    MessageFormatter: Fn(&'a Event, Option<ObjId>) -> [char; 2],
+{
+    // EXTRACT METADATA FROM MESSAGE SEGMENT
+    // All events in message segment should have same track and channel (guaranteed by grouping logic)
+    let Some(first_event) = message_segment.first() else {
+        return Token::Message {
+            track: Track(0),
+            channel: Channel::Bgm,
+            message: Cow::Borrowed(""),
+        };
+    };
+    let (track, channel) = (first_event.time.track(), first_event.channel);
+
+    // CALCULATE MESSAGE LENGTH
+    // Find the least common multiple (LCM) of all denominators to determine message length - this ensures
+    // all events in the message segment can be accurately positioned in the message string.
+    // Example: if we have events at 1/3 and 1/5, LCM(3,5)=15, so we need length 15 to represent them both accurately.
+    let denominators: Vec<u64> = message_segment
+        .iter()
+        .map(|event_unit| event_unit.time.denominator_u64())
+        .collect();
+    let lcm_denom = lcm_slice(&denominators);
+
+    let message_len = lcm_denom as usize;
+    let mut message_parts: Vec<String> = vec!["00".to_string(); message_len];
+
+    // PLACE EVENTS IN MESSAGE STRING
+    // For each event in the message segment, calculate its exact position in the message
+    // and place its value there. The time_idx calculation converts fractional time
+    // to array index using the formula: (numerator * lcm_denom / denominator)
+    for event_unit in message_segment {
+        let EventUnit {
+            event, id, time, ..
+        } = event_unit;
+        let chars = message_formatter(event, id);
+        let denom_u64 = time.denominator_u64();
+
+        // Calculate exact position: convert fraction to index in the message array
+        // Example: time=3/4, lcm_denom=4: (3 * 4 / 4) = 3, so place at index 3
+        // Example: time=1/3, lcm_denom=15: (1 * 15 / 3) = 5, so place at index 5
+        let time_idx = (time.numerator() * (lcm_denom / denom_u64)) as usize;
+
+        // Ensure we don't go out of bounds (safety check)
+        let Some(slot) = message_parts.get_mut(time_idx) else {
+            continue;
+        };
+        *slot = chars.iter().collect::<String>();
+    }
+
+    Token::Message {
+        track,
+        channel,
+        message: Cow::Owned(message_parts.join("")),
+    }
+}
+
+// ---- Private helpers on Bms for unparsing (moved from model.rs) ----
+
+impl Bms {
     fn unparse_headers<'a>(&'a self, tokens: &mut Vec<Token<'a>>) {
         // Options
         if let Some(options) = self.option.options.as_ref() {
@@ -330,7 +1244,6 @@ impl Bms {
         );
 
         // PoorBga mode
-
         if self.bmp.poor_bga_mode != PoorMode::default() {
             tokens.push(Token::Header {
                 name: "POORBGA".into(),
@@ -339,7 +1252,6 @@ impl Bms {
         }
 
         // Add basic definitions
-
         if let Some(base_bpm) = self.bpm.base_bpm.as_ref() {
             tokens.push(Token::Header {
                 name: "BASEBPM".into(),
@@ -365,13 +1277,11 @@ impl Bms {
         );
 
         self.unparse_def_tokens(tokens);
-
         self.unparse_resource_tokens(tokens);
     }
 
     fn unparse_def_tokens<'a>(&'a self, tokens: &mut Vec<Token<'a>>) {
         // Definitions in scope (existing ones first)
-        // Use iterator chains to efficiently collect all definition tokens
         tokens.extend(
             self.stop
                 .stop_defs
@@ -618,8 +1528,6 @@ impl Bms {
     }
 
     fn unparse_resource_tokens<'a>(&'a self, tokens: &mut Vec<Token<'a>>) {
-        // Resources - Use iterator chains to efficiently collect resource tokens
-        // Add basic resource tokens
         if let Some(path_root) = self.metadata.wav_path_root.as_ref() {
             tokens.push(Token::Header {
                 name: "PATH_WAV".into(),
@@ -699,951 +1607,6 @@ impl Bms {
                 args: self.volume.volume.relative_percent.to_string().into(),
             });
         }
-    }
-
-    fn unparse_messages<'a, T: KeyLayoutMapper>(
-        &'a self,
-        tokens: &mut Vec<Token<'a>>,
-        checker: &mut Base62Checker,
-    ) {
-        // Collect late definition tokens and message tokens
-        let mut late_def_tokens: Vec<Token<'a>> = Vec::new();
-        let mut message_tokens: Vec<Token<'a>> = Vec::new();
-
-        // Messages: Section length - Use iterator chain to collect tokens (sorted by track for consistent output)
-        let mut section_len_tokens: Vec<_> = self
-            .section_len
-            .section_len_changes
-            .values()
-            .map(|obj| Token::Message {
-                track: obj.track,
-                channel: Channel::SectionLen,
-                message: Cow::Owned(obj.length.to_string()),
-            })
-            .collect();
-        section_len_tokens.sort_by_key(|token| match token {
-            Token::Message { track, .. } => *track,
-            _ => Track(0),
-        });
-        message_tokens.extend(section_len_tokens);
-
-        // Helper closures for mapping definitions
-        // Note: We use f64::to_bits() as key since FinF64 doesn't implement Hash
-
-        let bpm_value_to_id: HashMap<u64, ObjId> = self
-            .bpm
-            .bpm_defs
-            .iter()
-            .filter_map(|(k, v)| {
-                v.value()
-                    .as_ref()
-                    .ok()
-                    .map(|val| (val.as_f64().to_bits(), *k))
-            })
-            .collect();
-        let stop_value_to_id: HashMap<u64, ObjId> = self
-            .stop
-            .stop_defs
-            .iter()
-            .filter_map(|(k, v)| {
-                v.value()
-                    .as_ref()
-                    .ok()
-                    .map(|val| (val.as_f64().to_bits(), *k))
-            })
-            .collect();
-        let scroll_value_to_id: HashMap<u64, ObjId> = self
-            .scroll
-            .scroll_defs
-            .iter()
-            .filter_map(|(k, v)| {
-                v.value()
-                    .as_ref()
-                    .ok()
-                    .map(|val| (val.as_f64().to_bits(), *k))
-            })
-            .collect();
-        let speed_value_to_id: HashMap<u64, ObjId> = self
-            .speed
-            .speed_defs
-            .iter()
-            .filter_map(|(k, v)| {
-                v.value()
-                    .as_ref()
-                    .ok()
-                    .map(|val| (val.as_f64().to_bits(), *k))
-            })
-            .collect();
-        let text_value_to_id: HashMap<&'a str, ObjId> = self
-            .text
-            .texts
-            .iter()
-            .map(|(k, v)| (v.as_str(), *k))
-            .collect();
-        let exrank_value_to_id: HashMap<&'a JudgeLevel, ObjId> = self
-            .judge
-            .exrank_defs
-            .iter()
-            .map(|(k, v)| (&v.judge_level, *k))
-            .collect();
-
-        let seek_value_to_id: HashMap<u64, ObjId> = self
-            .video
-            .seek_defs
-            .iter()
-            .filter_map(|(k, v)| {
-                v.value()
-                    .as_ref()
-                    .ok()
-                    .map(|val| (val.as_f64().to_bits(), *k))
-            })
-            .collect();
-
-        // Messages: BPM change (#xxx08 or #xxx03)
-        let mut bpm_message_tokens = Vec::new();
-
-        // Process U8 type BPM changes
-        let EventProcessingResult {
-            message_tokens: bpm_u8_message_tokens,
-            ..
-        } = build_event_messages(
-            self.bpm.bpm_changes_u8.iter(),
-            None::<(
-                fn(ObjId, &()) -> Token,
-                fn(&_) -> &(),
-                &mut ObjIdManager<()>,
-            )>,
-            |_ev| Channel::BpmChangeU8,
-            |bpm, _id| {
-                let s = format!("{bpm:02X}");
-                let mut chars = s.chars();
-                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-            },
-        );
-        bpm_message_tokens.extend(bpm_u8_message_tokens);
-
-        // Process other type BPM changes using build_event_messages_owned
-        let mut bpm_manager: HashMap<u64, ObjId> = bpm_value_to_id;
-        let EventProcessingResult {
-            late_def_tokens: other_late_def_tokens,
-            message_tokens: other_message_tokens,
-        } = build_event_messages_owned(
-            self.bpm.bpm_changes.iter(),
-            Some((
-                |id, bpm_bits: &u64| Token::Header {
-                    name: format!("BPM{id}").into(),
-                    args: f64::from_bits(*bpm_bits).to_string().into(),
-                },
-                |ev: &'a BpmChangeObj| ev.bpm.as_f64().to_bits(),
-                &mut bpm_manager,
-            )),
-            |_ev| Channel::BpmChange,
-            |_ev, id| {
-                let id = id.unwrap_or(ObjId::null());
-                id.into_chars()
-            },
-        );
-
-        // Update id_manager with the results
-        late_def_tokens.extend(other_late_def_tokens);
-        bpm_message_tokens.extend(other_message_tokens);
-
-        message_tokens.extend(bpm_message_tokens);
-
-        // Messages: STOP (#xxx09)
-        let mut stop_manager: HashMap<u64, ObjId> = stop_value_to_id;
-        let EventProcessingResult {
-            late_def_tokens: stop_late_def_tokens,
-            message_tokens: stop_message_tokens,
-        } = build_event_messages_owned(
-            self.stop.stops.iter(),
-            Some((
-                |id, duration_bits: &u64| Token::Header {
-                    name: format!("STOP{id}").into(),
-                    args: f64::from_bits(*duration_bits).to_string().into(),
-                },
-                |ev: &'a StopObj| ev.duration.as_f64().to_bits(),
-                &mut stop_manager,
-            )),
-            |_ev| Channel::Stop,
-            |_ev, id| {
-                let id = id.unwrap_or(ObjId::null());
-                id.into_chars()
-            },
-        );
-        late_def_tokens.extend(stop_late_def_tokens);
-        message_tokens.extend(stop_message_tokens);
-
-        // Messages: SCROLL (#xxxSC)
-        let mut scroll_manager: HashMap<u64, ObjId> = scroll_value_to_id;
-        let EventProcessingResult {
-            late_def_tokens: scroll_late_def_tokens,
-            message_tokens: scroll_message_tokens,
-        } = build_event_messages_owned(
-            self.scroll.scrolling_factor_changes.iter(),
-            Some((
-                |id, factor_bits: &u64| Token::Header {
-                    name: format!("SCROLL{id}").into(),
-                    args: f64::from_bits(*factor_bits).to_string().into(),
-                },
-                |ev: &'a ScrollingFactorObj| ev.factor.as_f64().to_bits(),
-                &mut scroll_manager,
-            )),
-            |_ev| Channel::Scroll,
-            |_ev, id| {
-                let id = id.unwrap_or(ObjId::null());
-                id.into_chars()
-            },
-        );
-        late_def_tokens.extend(scroll_late_def_tokens);
-        message_tokens.extend(scroll_message_tokens);
-
-        // Messages: SPEED (#xxxSP)
-        let mut speed_manager: HashMap<u64, ObjId> = speed_value_to_id;
-        let EventProcessingResult {
-            late_def_tokens: speed_late_def_tokens,
-            message_tokens: speed_message_tokens,
-        } = build_event_messages_owned(
-            self.speed.speed_factor_changes.iter(),
-            Some((
-                |id, factor_bits: &u64| Token::Header {
-                    name: format!("SPEED{id}").into(),
-                    args: f64::from_bits(*factor_bits).to_string().into(),
-                },
-                |ev: &'a SpeedObj| ev.factor.as_f64().to_bits(),
-                &mut speed_manager,
-            )),
-            |_ev| Channel::Speed,
-            |_ev, id| {
-                let id = id.unwrap_or(ObjId::null());
-                id.into_chars()
-            },
-        );
-        late_def_tokens.extend(speed_late_def_tokens);
-        message_tokens.extend(speed_message_tokens);
-
-        {
-            // STP events, sorted by time for consistent output
-            let mut stp_events: Vec<_> = self.stop.stp_events.values().collect();
-            stp_events.sort_by_key(|ev| ev.time);
-            tokens.extend(stp_events.into_iter().map(|ev| {
-                Token::Header {
-                    name: "STP".into(),
-                    args: format!(
-                        "{:03}.{:03} {}",
-                        ev.time.track(),
-                        ev.time.numerator() * ev.time.denominator_u64() / 1000,
-                        ev.duration.as_millis()
-                    )
-                    .into(),
-                }
-            }));
-        }
-
-        // Messages: BGA changes (#xxx04/#xxx07/#xxx06/#xxx0A)
-        let EventProcessingResult {
-            message_tokens: bga_message_tokens,
-            ..
-        } = build_event_messages(
-            self.bmp.bga_changes.iter(),
-            None::<(
-                fn(ObjId, &'a ()) -> Token<'a>,
-                fn(&_) -> &'a (),
-                &mut ObjIdManager<()>,
-            )>,
-            |bga| bga.layer.to_channel(),
-            |bga, _id| {
-                let s = bga.id.to_string();
-                let mut chars = s.chars();
-                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-            },
-        );
-        message_tokens.extend(bga_message_tokens);
-
-        {
-            // Messages: BGA opacity changes (#xxx0B/#xxx0C/#xxx0D/#xxx0E)
-            for (layer, opacity_changes) in &self.bmp.bga_opacity_changes {
-                let EventProcessingResult {
-                    message_tokens: opacity_message_tokens,
-                    ..
-                } = build_event_messages(
-                    opacity_changes.iter(),
-                    None::<(
-                        fn(ObjId, &'a ()) -> Token<'a>,
-                        fn(&_) -> &'a (),
-                        &mut ObjIdManager<()>,
-                    )>,
-                    |_ev| match layer {
-                        BgaLayer::Base => Channel::BgaBaseOpacity,
-                        BgaLayer::Poor => Channel::BgaPoorOpacity,
-                        BgaLayer::Overlay => Channel::BgaLayerOpacity,
-                        BgaLayer::Overlay2 => Channel::BgaLayer2Opacity,
-                    },
-                    |ev, _id| {
-                        let s = format!("{:02X}", ev.opacity);
-                        let mut chars = s.chars();
-                        [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-                    },
-                );
-                message_tokens.extend(opacity_message_tokens);
-            }
-
-            // Messages: BGA ARGB changes (#xxxA1/#xxxA2/#xxxA3/#xxxA4)
-            for (layer, argb_changes) in &self.bmp.bga_argb_changes {
-                let EventProcessingResult {
-                    message_tokens: argb_message_tokens,
-                    ..
-                } = build_event_messages(
-                    argb_changes.iter(),
-                    None::<(
-                        fn(ObjId, &'a ()) -> Token<'a>,
-                        fn(&_) -> &'a (),
-                        &mut ObjIdManager<()>,
-                    )>,
-                    |_ev| match layer {
-                        BgaLayer::Base => Channel::BgaBaseArgb,
-                        BgaLayer::Poor => Channel::BgaPoorArgb,
-                        BgaLayer::Overlay => Channel::BgaLayerArgb,
-                        BgaLayer::Overlay2 => Channel::BgaLayer2Argb,
-                    },
-                    |ev, _id| {
-                        let s = format!("{:02X}", ev.argb.alpha);
-                        let mut chars = s.chars();
-                        [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-                    },
-                );
-                message_tokens.extend(argb_message_tokens);
-            }
-        }
-
-        // Messages: BGM (#xxx01) and Notes (various #xx)
-        // Use build_event_messages to process note and BGM objects
-        // We need to preserve the original insertion order, so we process each object individually
-        let EventProcessingResult {
-            message_tokens: notes_message_tokens,
-            ..
-        } = build_event_messages(
-            self.wav
-                .notes
-                .all_notes_insertion_order()
-                .map(|obj| (&obj.offset, obj)),
-            None::<(
-                fn(ObjId, &()) -> Token,
-                fn(&_) -> &(),
-                &mut ObjIdManager<()>,
-            )>,
-            |obj| {
-                // Channel mapping: determine channel based on channel_id
-                obj.channel_id
-                    .try_into_map::<T>()
-                    .map_or(Channel::Bgm, |_map| Channel::Note {
-                        channel_id: obj.channel_id,
-                    })
-            },
-            |obj, _id| {
-                let s = obj.wav_id.to_string();
-                let mut chars = s.chars();
-                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-            }, // Message formatting: use wav_id
-        );
-
-        message_tokens.extend(notes_message_tokens);
-
-        // Messages: BGM volume (#97)
-        let EventProcessingResult {
-            message_tokens: bgm_volume_message_tokens,
-            ..
-        } = build_event_messages(
-            self.volume.bgm_volume_changes.iter(),
-            None::<(
-                fn(ObjId, &'a ()) -> Token<'a>,
-                fn(&_) -> &'a (),
-                &mut ObjIdManager<()>,
-            )>,
-            |_ev| Channel::BgmVolume,
-            |ev, _id| {
-                let s = format!("{:02X}", ev.volume);
-                let mut chars = s.chars();
-                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-            },
-        );
-        message_tokens.extend(bgm_volume_message_tokens);
-
-        // Messages: KEY volume (#98)
-        let EventProcessingResult {
-            message_tokens: key_volume_message_tokens,
-            ..
-        } = build_event_messages(
-            self.volume.key_volume_changes.iter(),
-            None::<(
-                fn(ObjId, &'a ()) -> Token<'a>,
-                fn(&_) -> &'a (),
-                &mut ObjIdManager<()>,
-            )>,
-            |_ev| Channel::KeyVolume,
-            |ev, _id| {
-                let s = format!("{:02X}", ev.volume);
-                let mut chars = s.chars();
-                [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-            },
-        );
-        message_tokens.extend(key_volume_message_tokens);
-
-        // Messages: TEXT (#99)
-        let mut text_manager =
-            ObjIdManager::from_entries(text_value_to_id.iter().map(|(k, v)| (*k, *v)));
-        let EventProcessingResult {
-            late_def_tokens: text_late_def_tokens,
-            message_tokens: text_message_tokens,
-        } = build_event_messages(
-            self.text.text_events.iter(),
-            Some((
-                |id, text: &'a str| Token::Header {
-                    name: format!("TEXT{id}").into(),
-                    args: text.into(),
-                },
-                |ev: &'a TextObj| ev.text.as_str(),
-                &mut text_manager,
-            )),
-            |_ev| Channel::Text,
-            |_ev, id| {
-                let id = id.unwrap_or(ObjId::null());
-                id.into_chars()
-            },
-        );
-        checker.check(text_manager.into_assigned_ids());
-        late_def_tokens.extend(text_late_def_tokens);
-        message_tokens.extend(text_message_tokens);
-
-        let mut exrank_manager =
-            ObjIdManager::from_entries(exrank_value_to_id.iter().map(|(k, v)| (*k, *v)));
-        let EventProcessingResult {
-            late_def_tokens: judge_late_def_tokens,
-            message_tokens: judge_message_tokens,
-        } = build_event_messages(
-            self.judge.judge_events.iter(),
-            Some((
-                |id, judge_level: &JudgeLevel| Token::Header {
-                    name: format!("EXRANK{id}").into(),
-                    args: judge_level.to_string().into(),
-                },
-                |ev: &'a JudgeObj| &ev.judge_level,
-                &mut exrank_manager,
-            )),
-            |_ev| Channel::Judge,
-            |_ev, id| {
-                let id = id.unwrap_or(ObjId::null());
-                id.into_chars()
-            },
-        );
-        checker.check(exrank_manager.into_assigned_ids());
-        late_def_tokens.extend(judge_late_def_tokens);
-        message_tokens.extend(judge_message_tokens);
-
-        if let Some(poor_bmp) = self.bmp.poor_bmp.as_ref()
-            && !poor_bmp.as_path().as_os_str().is_empty()
-        {
-            tokens.push(Token::Header {
-                name: "BMP00".into(),
-                args: poor_bmp.display().to_string().into(),
-            });
-        }
-
-        tokens.extend(
-            self.bmp
-                .bmp_files
-                .iter()
-                .filter(|(_, bmp)| !bmp.file.as_path().as_os_str().is_empty())
-                .map(|(id, bmp)| {
-                    (
-                        *id,
-                        if bmp.transparent_color == Argb::default() {
-                            Token::Header {
-                                name: format!("BMP{id}").into(),
-                                args: bmp.file.display().to_string().into(),
-                            }
-                        } else {
-                            Token::Header {
-                                name: format!("EXBMP{id}").into(),
-                                args: format!(
-                                    "{},{},{},{} {}",
-                                    bmp.transparent_color.alpha,
-                                    bmp.transparent_color.red,
-                                    bmp.transparent_color.green,
-                                    bmp.transparent_color.blue,
-                                    bmp.file.display()
-                                )
-                                .into(),
-                            }
-                        },
-                    )
-                })
-                .collect::<BTreeMap<_, _>>()
-                .into_values(),
-        );
-
-        {
-            // Messages: SEEK (#xxx05)
-            let mut seek_manager: HashMap<u64, ObjId> = seek_value_to_id;
-            let EventProcessingResult {
-                late_def_tokens: seek_late_def_tokens,
-                message_tokens: seek_message_tokens,
-            } = build_event_messages_owned(
-                self.video.seek_events.iter(),
-                Some((
-                    |id, position_bits: &u64| Token::Header {
-                        name: format!("SEEK{id}").into(),
-                        args: f64::from_bits(*position_bits).to_string().into(),
-                    },
-                    |ev: &'a SeekObj| ev.position.as_f64().to_bits(),
-                    &mut seek_manager,
-                )),
-                |_ev| Channel::Seek,
-                |_ev, id| {
-                    let id = id.unwrap_or(ObjId::null());
-                    let s = id.to_string();
-                    let mut chars = s.chars();
-                    [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-                },
-            );
-            late_def_tokens.extend(seek_late_def_tokens);
-            message_tokens.extend(seek_message_tokens);
-
-            // Messages: BGA keybound (#xxxA5)
-            let EventProcessingResult {
-                message_tokens: bga_keybound_message_tokens,
-                ..
-            } = build_event_messages(
-                self.bmp.bga_keybound_events.iter(),
-                None::<(
-                    fn(ObjId, &'a ()) -> Token<'a>,
-                    fn(&_) -> &'a (),
-                    &mut ObjIdManager<()>,
-                )>,
-                |_ev| Channel::BgaKeybound,
-                |ev, _id| {
-                    let s = format!("{:02X}", ev.event.line);
-                    let mut chars = s.chars();
-                    [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-                },
-            );
-            message_tokens.extend(bga_keybound_message_tokens);
-
-            // Messages: OPTION (#xxxA6)
-            let EventProcessingResult {
-                message_tokens: option_message_tokens,
-                ..
-            } = build_event_messages(
-                self.option.option_events.iter(),
-                None::<(
-                    fn(ObjId, &'a ()) -> Token<'a>,
-                    fn(&_) -> &'a (),
-                    &mut ObjIdManager<()>,
-                )>,
-                |_ev| Channel::OptionChange,
-                |_ev, _id| {
-                    let s = format!("{:02X}", 0);
-                    let mut chars = s.chars();
-                    [chars.next().unwrap_or('0'), chars.next().unwrap_or('0')]
-                }, // Option events don't use values
-            );
-            checker.check(seek_manager.values().copied());
-            message_tokens.extend(option_message_tokens);
-        };
-
-        // Assembly: header/definitions/resources/others -> late definitions -> messages
-        if !late_def_tokens.is_empty() {
-            tokens.extend(late_def_tokens);
-        }
-        if !message_tokens.is_empty() {
-            tokens.extend(message_tokens);
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct Base62Checker {
-    using_base62: bool,
-}
-
-impl Base62Checker {
-    const fn new() -> Self {
-        Self {
-            using_base62: false,
-        }
-    }
-
-    fn check(&mut self, iter: impl IntoIterator<Item = ObjId>) {
-        if !self.using_base62 && iter.into_iter().any(|id| !id.is_base36() && id.is_base62()) {
-            self.using_base62 = true;
-        }
-    }
-
-    const fn into_using_base62(self) -> bool {
-        self.using_base62
-    }
-}
-
-/// A unit of event processing containing all necessary information for token generation
-#[derive(Debug, Clone)]
-struct EventUnit<'a, Event> {
-    time: ObjTime,
-    event: &'a Event,
-    channel: Channel,
-    id: Option<ObjId>,
-}
-
-/// Complete result from `build_messages_event` containing all processing outputs
-struct EventProcessingResult<'a> {
-    message_tokens: Vec<Token<'a>>,
-    late_def_tokens: Vec<Token<'a>>,
-}
-
-/// Generic function to process message types with optional ID allocation
-///
-/// This function processes time-indexed events from an iterator and converts them into message tokens.
-/// It supports both ID allocation mode (using `token_creator` and `key_extractor`) and direct mode (without ID allocation).
-///
-/// # PROCESSING FLOW OVERVIEW:
-/// 1. **GROUP EVENTS**: Events are grouped by track, channel, and non-strictly increasing time
-/// 2. **SPLIT INTO MESSAGE SEGMENTS**: Each group is further split into message segments with stricter rules:
-///    - Strictly increasing time (prevents overlaps)
-///    - Consistent denominators (ensures accurate representation)
-/// 3. **GENERATE TOKENS**: Each message segment becomes one `Token::Message` with all events encoded
-///
-/// Arguments:
-///     events: An iterator yielding (&time, &event) pairs to process
-///     `id_allocation`: Optional tuple containing (`token_creator`, `key_extractor`, `id_manager`) for ID allocation mode
-///     `channel_mapper`: Function to map events to channels
-///     `message_formatter`: Function to format events into [char; 2]
-///
-/// Returns:
-///     `EventProcessingResult` containing `message_tokens`, `late_def_tokens`, and updated maps
-///
-/// The function leverages Rust's iterator chains for efficient processing and supports
-/// both ID-based and direct value-based event processing.
-fn build_event_messages<
-    'a,
-    Event: 'a,
-    Key: 'a + ?Sized + std::hash::Hash + Eq,
-    EventIterator,
-    TokenCreator,
-    KeyExtractor,
-    ChannelMapper,
-    MessageFormatter,
->(
-    event_iter: EventIterator,
-    mut id_allocation: Option<(TokenCreator, KeyExtractor, &mut ObjIdManager<'a, Key>)>,
-    channel_mapper: ChannelMapper,
-    message_formatter: MessageFormatter,
-) -> EventProcessingResult<'a>
-where
-    EventIterator: Iterator<Item = (&'a ObjTime, &'a Event)>,
-    TokenCreator: Fn(ObjId, &'a Key) -> Token<'a>,
-    KeyExtractor: Fn(&'a Event) -> &'a Key,
-    ChannelMapper: Fn(&'a Event) -> Channel,
-    MessageFormatter: Fn(&'a Event, Option<ObjId>) -> [char; 2],
-{
-    let mut late_def_tokens: Vec<Token<'a>> = Vec::new();
-
-    // Process events based on whether id_allocation tuple is provided
-    // Keep original order from event_iter instead of grouping by track/channel
-    let processed_events: Vec<EventUnit<'a, Event>> = event_iter
-        .map(|(&time, event)| {
-            let id = id_allocation
-                .as_mut()
-                .and_then(|(token_creator, key_extractor, manager)| {
-                    let key = key_extractor(event);
-                    let is_assigned = manager.is_assigned(key);
-                    let id = manager.get_or_new_id(key);
-                    if !is_assigned && let Some(new) = id {
-                        late_def_tokens.push(token_creator(new, key));
-                    }
-                    id
-                });
-            EventUnit {
-                time,
-                event,
-                channel: channel_mapper(event),
-                id,
-            }
-        })
-        .collect();
-
-    // === STEP 1: GROUP EVENTS BY TRACK, CHANNEL, AND TIME ===
-    // Group events by adjacent same track, channel and non-strictly increasing time
-    //
-    // This creates the first level of grouping where events that share:
-    // - Preserve the original event iterator order
-    // - Same track number
-    // - Same channel type
-    // - Non-strictly increasing time (last_time <= current_time)
-    // ...are grouped together. This is the foundation for efficient message generation.
-    let grouped_events = group_events_by_track_channel_time(processed_events);
-
-    // === STEP 2: SPLIT GROUPS INTO MESSAGE SEGMENTS ===
-    // Split each group into message segments based on time ordering and denominator consistency
-    //
-    // This creates the second level of grouping with stricter rules:
-    // - Not preserve the original event iterator order
-    // - Time must be strictly increasing (last_time < current_time)
-    // - Denominators must be the same starting from the second element
-    // - First element can have 0 numerator, or the same denominator as elements after it
-    //
-    // The purpose is to ensure that events within a message segment can be represented
-    // in a single message string without conflicts or information loss.
-    let message_segmented_events: Vec<Vec<_>> = grouped_events
-        .into_iter()
-        .flat_map(split_group_into_message_segments)
-        .collect();
-
-    // === STEP 3: GENERATE MESSAGE TOKENS FROM MESSAGE SEGMENTS ===
-    // Generate message tokens: each message segment generates one Token::Message
-    //
-    // This is the final step where each message segment is converted into a single Token::Message.
-    // The process ensures that all events in a message segment are represented in one message string
-    // with correct timing and without information loss.
-    let message_tokens: Vec<Token<'a>> = message_segmented_events
-        .into_iter()
-        .map(|message_segment| {
-            convert_message_segment_to_token(message_segment, &message_formatter)
-        })
-        .collect();
-
-    EventProcessingResult {
-        message_tokens,
-        late_def_tokens,
-    }
-}
-
-/// A version of `build_event_messages` that supports owned keys (like u64 instead of &u64)
-fn build_event_messages_owned<
-    'a,
-    Event: 'a,
-    Key: std::hash::Hash + Eq + Clone,
-    EventIterator,
-    TokenCreator,
-    KeyExtractor,
-    ChannelMapper,
-    MessageFormatter,
->(
-    event_iter: EventIterator,
-    mut id_allocation: Option<(TokenCreator, KeyExtractor, &mut HashMap<Key, ObjId>)>,
-    channel_mapper: ChannelMapper,
-    message_formatter: MessageFormatter,
-) -> EventProcessingResult<'a>
-where
-    EventIterator: Iterator<Item = (&'a ObjTime, &'a Event)>,
-    TokenCreator: Fn(ObjId, &Key) -> Token<'a>,
-    KeyExtractor: Fn(&'a Event) -> Key,
-    ChannelMapper: Fn(&'a Event) -> Channel,
-    MessageFormatter: Fn(&'a Event, Option<ObjId>) -> [char; 2],
-{
-    let mut late_def_tokens: Vec<Token<'a>> = Vec::new();
-
-    // Process events based on whether id_allocation tuple is provided
-    let processed_events: Vec<EventUnit<'a, Event>> = event_iter
-        .map(|(&time, event)| {
-            let id = id_allocation
-                .as_mut()
-                .and_then(|(token_creator, key_extractor, manager)| {
-                    let key = key_extractor(event);
-                    let _is_assigned = manager.contains_key(&key);
-
-                    manager.get(&key).copied().or_else(|| {
-                        let new_id =
-                            ObjId::all_values().find(|id| !manager.values().any(|&v| v == *id));
-                        if let Some(new_id) = new_id {
-                            manager.insert(key.clone(), new_id);
-                            late_def_tokens.push(token_creator(new_id, &key));
-                        }
-                        new_id
-                    })
-                });
-            EventUnit {
-                time,
-                event,
-                channel: channel_mapper(event),
-                id,
-            }
-        })
-        .collect();
-
-    let grouped_events = group_events_by_track_channel_time(processed_events);
-    let message_segmented_events: Vec<Vec<_>> = grouped_events
-        .into_iter()
-        .flat_map(split_group_into_message_segments)
-        .collect();
-    let message_tokens: Vec<Token<'a>> = message_segmented_events
-        .into_iter()
-        .map(|message_segment| {
-            convert_message_segment_to_token(message_segment, &message_formatter)
-        })
-        .collect();
-
-    EventProcessingResult {
-        message_tokens,
-        late_def_tokens,
-    }
-}
-
-/// Group events by track, channel, and non-strictly increasing time
-fn group_events_by_track_channel_time<'a, Event>(
-    processed_events: Vec<EventUnit<'a, Event>>,
-) -> Vec<Vec<EventUnit<'a, Event>>> {
-    let mut groups = Vec::new();
-    let mut current_group = Vec::new();
-
-    for event_unit in processed_events {
-        let should_join = current_group
-            .last()
-            .is_some_and(|last_unit: &EventUnit<'a, Event>| {
-                event_unit.time.track() == last_unit.time.track()
-                    && last_unit.channel == event_unit.channel
-                    && last_unit.time <= event_unit.time
-            });
-
-        if should_join {
-            current_group.push(event_unit);
-        } else {
-            if !current_group.is_empty() {
-                groups.push(current_group);
-            }
-            current_group = vec![event_unit];
-        }
-    }
-
-    if !current_group.is_empty() {
-        groups.push(current_group);
-    }
-    groups
-}
-
-/// Split a group into message segments based on time ordering and denominator consistency
-fn split_group_into_message_segments<'a, Event>(
-    group: Vec<EventUnit<'a, Event>>,
-) -> Vec<Vec<EventUnit<'a, Event>>> {
-    let mut message_segments = Vec::new();
-    let mut current_message_segment = Vec::new();
-
-    for event_unit in group {
-        let should_join =
-            current_message_segment
-                .last()
-                .is_none_or(|last_unit: &EventUnit<'a, Event>| {
-                    // MESSAGE SEGMENT JOINING RULES:
-                    // 1. Time must be strictly increasing (prevents overlapping events)
-                    // 2. Denominators must be compatible:
-                    //    - If current message segment is empty, accept any denominator
-                    //    - Otherwise, denominators must share a factor relationship (either is a factor of the other)
-                    //    - Reference denominator is the maximum denominator currently in the message segment
-                    (last_unit.time < event_unit.time)
-                        && (current_message_segment.is_empty()
-                            || is_denominator_compatible(&event_unit, &current_message_segment))
-                }); // Empty message segment always accepts the first event
-
-        if should_join {
-            current_message_segment.push(event_unit);
-        } else {
-            if !current_message_segment.is_empty() {
-                message_segments.push(current_message_segment);
-            }
-            current_message_segment = vec![event_unit];
-        }
-    }
-
-    if !current_message_segment.is_empty() {
-        message_segments.push(current_message_segment);
-    }
-    message_segments
-}
-
-/// Check if an event unit's denominator is compatible with the current message segment
-/// Two denominators are compatible if either is a factor of the other
-fn is_denominator_compatible<'a, Event>(
-    event_unit: &EventUnit<'a, Event>,
-    message_segment: &[EventUnit<'a, Event>],
-) -> bool {
-    // Find the maximum denominator from the current message segment as reference
-    let reference_denominator = message_segment
-        .iter()
-        .map(|unit| unit.time.denominator_u64())
-        .max()
-        .unwrap_or(1);
-
-    // Check if the event unit's denominator shares a common factor relationship
-    let event_denominator = event_unit.time.denominator_u64();
-    reference_denominator.is_multiple_of(event_denominator)
-        || event_denominator.is_multiple_of(reference_denominator)
-}
-
-/// Convert a message segment of events into a single `Token::Message`
-fn convert_message_segment_to_token<'a, Event, MessageFormatter>(
-    message_segment: Vec<EventUnit<'a, Event>>,
-    message_formatter: &MessageFormatter,
-) -> Token<'a>
-where
-    MessageFormatter: Fn(&'a Event, Option<ObjId>) -> [char; 2],
-{
-    if message_segment.is_empty() {
-        return Token::Message {
-            track: Track(0),
-            channel: Channel::Bgm,
-            message: Cow::Borrowed(""),
-        };
-    }
-
-    // EXTRACT METADATA FROM MESSAGE SEGMENT
-    // All events in message segment should have same track and channel (guaranteed by grouping logic)
-    let Some(first_event) = message_segment.first() else {
-        return Token::Message {
-            track: Track(0),
-            channel: Channel::Bgm,
-            message: Cow::Borrowed(""),
-        };
-    };
-    let (track, channel) = (first_event.time.track(), first_event.channel);
-
-    // CALCULATE MESSAGE LENGTH
-    // Find the least common multiple (LCM) of all denominators to determine message length - this ensures
-    // all events in the message segment can be accurately positioned in the message string.
-    // Example: if we have events at 1/3 and 1/5, LCM(3,5)=15, so we need length 15 to represent them both accurately.
-    let denominators: Vec<u64> = message_segment
-        .iter()
-        .map(|event_unit| event_unit.time.denominator_u64())
-        .collect();
-    let lcm_denom = lcm_slice(&denominators);
-
-    let message_len = lcm_denom as usize;
-    let mut message_parts: Vec<String> = vec!["00".to_string(); message_len];
-
-    // PLACE EVENTS IN MESSAGE STRING
-    // For each event in the message segment, calculate its exact position in the message
-    // and place its value there. The time_idx calculation converts fractional time
-    // to array index using the formula: (numerator * lcm_denom / denominator)
-    for event_unit in message_segment {
-        let EventUnit {
-            event, id, time, ..
-        } = event_unit;
-        let chars = message_formatter(event, id);
-        let denom_u64 = time.denominator_u64();
-
-        // Calculate exact position: convert fraction to index in the message array
-        // Example: time=3/4, lcm_denom=4: (3 * 4 / 4) = 3, so place at index 3
-        // Example: time=1/3, lcm_denom=15: (1 * 15 / 3) = 5, so place at index 5
-        let time_idx = (time.numerator() * (lcm_denom / denom_u64)) as usize;
-
-        // Ensure we don't go out of bounds (safety check)
-        let Some(slot) = message_parts.get_mut(time_idx) else {
-            continue;
-        };
-        *slot = chars.iter().collect::<String>();
-    }
-
-    Token::Message {
-        track,
-        channel,
-        message: Cow::Owned(message_parts.join("")),
     }
 }
 

--- a/src/bmson/bms_to_bmson.rs
+++ b/src/bmson/bms_to_bmson.rs
@@ -147,12 +147,12 @@ impl Bms {
                 // TODO: Support other modes
                 let is_7keys = self.wav.notes.all_notes().any(|note| {
                     note.channel_id
-                        .try_into_map::<KeyLayoutBeat>()
+                        .try_into_map::<BmsLayoutBeat>()
                         .is_some_and(|map| matches!(map.key(), Key::Key(6 | 7)))
                 });
                 let is_dp = self.wav.notes.all_notes().any(|note| {
                     note.channel_id
-                        .try_into_map::<KeyLayoutBeat>()
+                        .try_into_map::<BmsLayoutBeat>()
                         .is_some_and(|map| map.side() == PlayerSide::Player2)
                 });
                 match (is_dp, is_7keys) {
@@ -232,7 +232,7 @@ impl Bms {
             for note in self.wav.notes.all_notes() {
                 let note_lane = note
                     .channel_id
-                    .try_into_map::<KeyLayoutBeat>()
+                    .try_into_map::<BmsLayoutBeat>()
                     .filter(|map| map.kind().is_playable())
                     .map(|map|
                         match map.key() {
@@ -256,7 +256,7 @@ impl Bms {
                 let pulses = converter.get_pulses_at(note.offset);
                 match note
                     .channel_id
-                    .try_into_map::<KeyLayoutBeat>()
+                    .try_into_map::<BmsLayoutBeat>()
                     .map(|map| map.kind())
                 {
                     Some(NoteKind::Landmine) => {

--- a/src/bmson/bmson_to_bms.rs
+++ b/src/bmson/bmson_to_bms.rs
@@ -186,7 +186,7 @@ impl Bms {
 
                 let obj = WavObj {
                     offset: time,
-                    channel_id: KeyLayoutBeat::new(side, kind, key).to_channel_id(),
+                    channel_id: BmsLayoutBeat::new(side, kind, key).to_channel_id(),
                     wav_id: obj_id,
                 };
                 bms.wav.notes.push_note(obj);
@@ -208,7 +208,7 @@ impl Bms {
 
                 let obj = WavObj {
                     offset: time,
-                    channel_id: KeyLayoutBeat::new(side, NoteKind::Landmine, key).to_channel_id(),
+                    channel_id: BmsLayoutBeat::new(side, NoteKind::Landmine, key).to_channel_id(),
                     wav_id: obj_id,
                 };
                 bms.wav.notes.push_note(obj);
@@ -230,7 +230,7 @@ impl Bms {
 
                 let obj = WavObj {
                     offset: time,
-                    channel_id: KeyLayoutBeat::new(side, NoteKind::Invisible, key).to_channel_id(),
+                    channel_id: BmsLayoutBeat::new(side, NoteKind::Invisible, key).to_channel_id(),
                     wav_id: obj_id,
                 };
                 bms.wav.notes.push_note(obj);
@@ -307,7 +307,7 @@ impl Bms {
         let PlayingCheckOutput {
             playing_warnings,
             playing_errors,
-        } = bms.check_playing::<KeyLayoutBeat>();
+        } = bms.check_playing::<BmsLayoutBeat>();
 
         BmsonToBmsOutput {
             bms,

--- a/src/bmson/prelude.rs
+++ b/src/bmson/prelude.rs
@@ -31,6 +31,3 @@ pub use super::{default_mode_hint, default_percentage, default_resolution};
 
 // Re-export BMS types that are dependencies of BMSON types
 pub use crate::bms::command::LnMode;
-
-// Re-export process module
-pub use super::process::BmsonProcessor;

--- a/src/bmson/process.rs
+++ b/src/bmson/process.rs
@@ -25,7 +25,7 @@ use crate::util::StrExtension;
 ///
 /// This struct serves as a namespace for BMSON parsing functions.
 /// It parses BMSON files and returns a `Chart` containing all precomputed data.
-pub struct BmsonProcessor;
+struct BmsonProcessor;
 
 impl BmsonProcessor {
     /// Parse BMSON file and return a `Chart` containing all precomputed data.
@@ -34,7 +34,7 @@ impl BmsonProcessor {
     ///
     /// Panics if `init_bpm` is not a positive number.
     #[must_use]
-    pub fn parse(bmson: &Bmson<'_>) -> Chart {
+    fn parse(bmson: &Bmson<'_>) -> Chart {
         let init_bpm: PositiveF64 =
             PositiveF64::new(bmson.info.init_bpm.as_f64()).expect("init_bpm should be positive");
         let pulses_denom = FinF64::new((4 * bmson.info.resolution.get()) as f64)
@@ -439,15 +439,15 @@ impl<'a> TryFrom<Bmson<'a>> for Chart {
     type Error = ();
 
     fn try_from(bmson: Bmson<'a>) -> Result<Self, Self::Error> {
-        Ok(BmsonProcessor::parse(&bmson))
+        bmson.process()
     }
 }
 
 impl Process for Bmson<'_> {
     type Error = ();
 
-    fn process(self) -> Result<Chart, Self::Error> {
-        Ok(BmsonProcessor::parse(&self))
+    fn process(&self) -> Result<Chart, Self::Error> {
+        Ok(BmsonProcessor::parse(self))
     }
 }
 

--- a/src/chart/player.rs
+++ b/src/chart/player.rs
@@ -66,7 +66,7 @@ impl<'a> ChartPlayer<'a> {
     /// let start_time = TimeStamp::now();
     /// let base_bpm = StartBpmGenerator.generate(&bms)?;
     /// let visible_range = VisibleRangePerBpm::new(base_bpm, reaction_time);
-    /// let chart = BmsProcessor::parse(&bms);
+    /// let chart = bms.process().unwrap();
     ///
     /// let mut player = ChartPlayer::start(&chart, visible_range, start_time);
     /// ```

--- a/src/chart/process.rs
+++ b/src/chart/process.rs
@@ -21,7 +21,7 @@ pub trait Process {
     /// # Errors
     ///
     /// Returns `Self::Error` if processing fails.
-    fn process(self) -> Result<Chart, Self::Error>;
+    fn process(&self) -> Result<Chart, Self::Error>;
 }
 
 /// WAV audio file ID wrapper type

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -14,7 +14,7 @@
 //! # #[cfg(feature = "diagnostics")]
 //! # {
 //! use bms_rs::{
-//!     bms::{BmsWarning, default_config, command::channel::mapper::KeyLayoutBeat, parse_bms},
+//!     bms::{BmsWarning, default_config, command::channel::mapper::BmsLayoutBeat, parse_bms},
 //!     diagnostics::emit_bms_warnings,
 //! };
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! use bms_rs::bms::{BmsOutput, rng::RngMock, default_config_with_rng, parse_bms};
 //! #[cfg(not(feature = "rand"))]
 //! use num::BigUint;
-//! use bms_rs::bms::{command::channel::mapper::KeyLayoutBeat, BmsWarning};
+//! use bms_rs::bms::{command::channel::mapper::BmsLayoutBeat, BmsWarning};
 //!
 //! let source = std::fs::read_to_string("tests/bms/files/lilith_mx.bms").unwrap();
 //! #[cfg(feature = "rand")]
@@ -40,7 +40,7 @@
 //! #[cfg(feature = "rand")]
 //! use rand::{rngs::StdRng, SeedableRng};
 //! use bms_rs::bms::prelude::*;
-//! use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
+//! use bms_rs::bms::command::channel::mapper::BmsLayoutBeat;
 //! use num::BigUint;
 //!
 //! let source = std::fs::read_to_string("tests/bms/files/lilith_mx.bms").unwrap();
@@ -58,7 +58,7 @@
 //! );
 //! let bms = parse_output.bms.expect("must be parsed");
 //! // According to [BMS command memo#BEHAVIOR IN GENERAL IMPLEMENTATION](https://hitkey.bms.ms/cmds.htm#BEHAVIOR-IN-GENERAL-IMPLEMENTATION), the newer values are used for the duplicated objects.
-//! let PlayingCheckOutput { playing_warnings, playing_errors } = bms.check_playing::<KeyLayoutBeat>();
+//! let PlayingCheckOutput { playing_warnings, playing_errors } = bms.check_playing::<BmsLayoutBeat>();
 //! assert_eq!(playing_warnings, vec![]);
 //! assert_eq!(playing_errors, vec![]);
 //! println!("Title: {}", bms.music_info.title.as_deref().unwrap_or("Unknown"));

--- a/tests/bms/base_62.rs
+++ b/tests/bms/base_62.rs
@@ -16,10 +16,7 @@ fn test_not_base_62() {
     let ParseOutput {
         bms,
         parse_warnings,
-    } = Bms::from_token_stream::<'_, KeyLayoutBeat, _, _, _>(
-        &tokens,
-        default_config().prompter(AlwaysUseNewer),
-    );
+    } = Bms::from_token_stream(&tokens, default_config().prompter(AlwaysUseNewer));
     assert_eq!(parse_warnings, vec![]);
     let bms = bms.expect("no errors");
     eprintln!("{bms:?}");
@@ -47,10 +44,7 @@ fn test_base_62() {
     let ParseOutput {
         bms,
         parse_warnings,
-    } = Bms::from_token_stream::<'_, KeyLayoutBeat, _, _, _>(
-        &tokens,
-        default_config().prompter(AlwaysUseNewer),
-    );
+    } = Bms::from_token_stream(&tokens, default_config().prompter(AlwaysUseNewer));
     assert_eq!(parse_warnings, vec![]);
     let bms = bms.expect("no errors");
     eprintln!("{bms:?}");

--- a/tests/bms/control_flow_model.rs
+++ b/tests/bms/control_flow_model.rs
@@ -75,7 +75,7 @@ fn test_nested_random_structure() {
         branch1.sub.notes().all_notes().cloned().collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 1, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                 .to_channel_id(),
             wav_id: ObjId::try_from("22", false).unwrap(),
         }]
@@ -108,7 +108,7 @@ fn test_nested_random_structure() {
             .collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 1, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                 .to_channel_id(),
             wav_id: ObjId::try_from("55", false).unwrap(),
         }]
@@ -142,14 +142,14 @@ fn test_nested_random_structure() {
         branch2.sub.notes().all_notes().cloned().collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 2, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                 .to_channel_id(),
             wav_id: ObjId::try_from("33", false).unwrap(),
         }]
     );
 
     let rnd_strings_outer = random_obj
-        .export_as_random::<KeyLayoutBeat>()
+        .export_as_random(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -167,7 +167,7 @@ fn test_nested_random_structure() {
     );
 
     let sw_strings_outer = random_obj
-        .export_as_switch::<KeyLayoutBeat>()
+        .export_as_switch(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -186,7 +186,7 @@ fn test_nested_random_structure() {
     );
 
     let rnd_strings_nested = nested_random
-        .export_as_random::<KeyLayoutBeat>()
+        .export_as_random(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -204,7 +204,7 @@ fn test_nested_random_structure() {
     );
 
     let sw_strings_nested = nested_random
-        .export_as_switch::<KeyLayoutBeat>()
+        .export_as_switch(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -292,7 +292,7 @@ fn test_nested_switch_structure() {
         case1.sub.notes().all_notes().cloned().collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 1, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                 .to_channel_id(),
             wav_id: ObjId::try_from("22", false).unwrap(),
         }]
@@ -324,7 +324,7 @@ fn test_nested_switch_structure() {
             .collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 1, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                 .to_channel_id(),
             wav_id: ObjId::try_from("55", false).unwrap(),
         }]
@@ -358,14 +358,14 @@ fn test_nested_switch_structure() {
         case2.sub.notes().all_notes().cloned().collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 2, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                 .to_channel_id(),
             wav_id: ObjId::try_from("33", false).unwrap(),
         }]
     );
 
     let sw_strings_outer = switch_obj
-        .export_as_switch::<KeyLayoutBeat>()
+        .export_as_switch(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -384,7 +384,7 @@ fn test_nested_switch_structure() {
     );
 
     let rnd_strings_outer = switch_obj
-        .export_as_random::<KeyLayoutBeat>()
+        .export_as_random(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -402,7 +402,7 @@ fn test_nested_switch_structure() {
     );
 
     let nested_switch_strings = nested_switch
-        .export_as_switch::<KeyLayoutBeat>()
+        .export_as_switch(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -421,7 +421,7 @@ fn test_nested_switch_structure() {
     );
 
     let nested_rnd_strings = nested_switch
-        .export_as_random::<KeyLayoutBeat>()
+        .export_as_random(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -491,7 +491,7 @@ fn test_export_as_random_tokens() {
         .randomized
         .first()
         .expect("expected exactly 1 randomized block");
-    let rnd_tokens = rnd.export_as_random::<KeyLayoutBeat>();
+    let rnd_tokens = rnd.export_as_random(&Bms::unparse);
     let strings = rnd_tokens
         .into_iter()
         .map(|t| t.to_string())
@@ -510,7 +510,7 @@ fn test_export_as_random_tokens() {
     );
 
     let sw_strings = rnd
-        .export_as_switch::<KeyLayoutBeat>()
+        .export_as_switch(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -568,7 +568,7 @@ fn test_export_as_switch_tokens() {
         .randomized
         .first()
         .expect("expected exactly 1 randomized block");
-    let sw_tokens = sw.export_as_switch::<KeyLayoutBeat>();
+    let sw_tokens = sw.export_as_switch(&Bms::unparse);
     let strings = sw_tokens
         .into_iter()
         .map(|t| t.to_string())
@@ -589,7 +589,7 @@ fn test_export_as_switch_tokens() {
     );
 
     let rnd_strings = sw
-        .export_as_random::<KeyLayoutBeat>()
+        .export_as_random(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -656,7 +656,7 @@ fn test_switch_fallthrough_one_skip() {
         case1.sub.notes().all_notes().cloned().collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 1, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                 .to_channel_id(),
             wav_id: ObjId::try_from("22", false).unwrap(),
         }]
@@ -670,13 +670,13 @@ fn test_switch_fallthrough_one_skip() {
         case2.sub.notes().all_notes().cloned().collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 2, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                 .to_channel_id(),
             wav_id: ObjId::try_from("33", false).unwrap(),
         }]
     );
 
-    let sw_tokens = sw.export_as_switch::<KeyLayoutBeat>();
+    let sw_tokens = sw.export_as_switch(&Bms::unparse);
     let strings = sw_tokens
         .into_iter()
         .map(|t| t.to_string())
@@ -696,7 +696,7 @@ fn test_switch_fallthrough_one_skip() {
     );
 
     let rnd_strings = sw
-        .export_as_random::<KeyLayoutBeat>()
+        .export_as_random(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -763,7 +763,7 @@ fn test_switch_default_then_case_override() {
         case1.sub.notes().all_notes().cloned().collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 1, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                 .to_channel_id(),
             wav_id: ObjId::try_from("22", false).unwrap(),
         }]
@@ -777,13 +777,13 @@ fn test_switch_default_then_case_override() {
         case2.sub.notes().all_notes().cloned().collect::<Vec<_>>(),
         vec![WavObj {
             offset: ObjTime::new(1, 2, 4).unwrap(),
-            channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
+            channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                 .to_channel_id(),
             wav_id: ObjId::try_from("33", false).unwrap(),
         }]
     );
 
-    let sw_tokens = sw.export_as_switch::<KeyLayoutBeat>();
+    let sw_tokens = sw.export_as_switch(&Bms::unparse);
     let strings = sw_tokens
         .into_iter()
         .map(|t| t.to_string())
@@ -803,7 +803,7 @@ fn test_switch_default_then_case_override() {
     );
 
     let rnd_strings = sw
-        .export_as_random::<KeyLayoutBeat>()
+        .export_as_random(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -874,7 +874,7 @@ fn test_export_both_and_compare() {
         .get(1)
         .expect("expected at least 2 randomized blocks");
 
-    let sw_tokens = sw.export_as_switch::<KeyLayoutBeat>();
+    let sw_tokens = sw.export_as_switch(&Bms::unparse);
     let sw_strings = sw_tokens
         .into_iter()
         .map(|t| t.to_string())
@@ -893,7 +893,7 @@ fn test_export_both_and_compare() {
         ]
     );
 
-    let rnd_tokens = rnd.export_as_random::<KeyLayoutBeat>();
+    let rnd_tokens = rnd.export_as_random(&Bms::unparse);
     let rnd_strings = rnd_tokens
         .into_iter()
         .map(|t| t.to_string())
@@ -978,7 +978,7 @@ fn test_export_both_and_compare_different_contents() {
         .expect("expected at least 2 randomized blocks");
 
     let sw_strings = sw
-        .export_as_switch::<KeyLayoutBeat>()
+        .export_as_switch(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();
@@ -997,7 +997,7 @@ fn test_export_both_and_compare_different_contents() {
     );
 
     let rnd_strings = rnd
-        .export_as_random::<KeyLayoutBeat>()
+        .export_as_random(&Bms::unparse)
         .into_iter()
         .map(|t| t.to_string())
         .collect::<Vec<_>>();

--- a/tests/bms/extra_channel.rs
+++ b/tests/bms/extra_channel.rs
@@ -107,10 +107,8 @@ fn test_channel_judge() {
     #001A0:01000200
     #002A0:02000100
     ";
-    let BmsOutput { bms, warnings } = parse_bms::<KeyLayoutBeat, _, _, _>(
-        src,
-        default_config_with_rng(RngMock([BigUint::from(1u64)])),
-    );
+    let BmsOutput { bms, warnings } =
+        parse_bms(src, default_config_with_rng(RngMock([BigUint::from(1u64)])));
     let bms = bms.unwrap();
     assert_eq!(
         warnings
@@ -156,10 +154,8 @@ fn test_bga_opacity_channels() {
     #0010D:A0
     #0010E:B0
     ";
-    let BmsOutput { bms, warnings } = parse_bms::<KeyLayoutBeat, _, _, _>(
-        src,
-        default_config_with_rng(RngMock([BigUint::from(1u64)])),
-    );
+    let BmsOutput { bms, warnings } =
+        parse_bms(src, default_config_with_rng(RngMock([BigUint::from(1u64)])));
     let bms = bms.unwrap();
     assert_eq!(
         warnings
@@ -243,10 +239,8 @@ fn test_bga_argb_channels() {
     #001A3:03010204
     #001A4:04010203
     ";
-    let BmsOutput { bms, warnings } = parse_bms::<KeyLayoutBeat, _, _, _>(
-        src,
-        default_config_with_rng(RngMock([BigUint::from(1u64)])),
-    );
+    let BmsOutput { bms, warnings } =
+        parse_bms(src, default_config_with_rng(RngMock([BigUint::from(1u64)])));
     let bms = bms.unwrap();
     assert_eq!(
         warnings

--- a/tests/bms/files.rs
+++ b/tests/bms/files.rs
@@ -149,13 +149,16 @@ fn test_bemuse_ext() {
     let source = include_str!("files/bemuse_ext.bms");
     let BmsOutput { bms, warnings } = parse_bms(source, default_config());
     let bms = bms.unwrap();
+    assert_eq!(warnings, vec![]);
+
+    let PlayingCheckOutput {
+        playing_warnings,
+        playing_errors,
+    } = bms.check_playing::<BmsLayoutBeat>();
+    assert_eq!(playing_warnings, vec![PlayingWarning::TotalUndefined]);
     assert_eq!(
-        warnings,
-        vec![
-            BmsWarning::PlayingWarning(PlayingWarning::TotalUndefined),
-            BmsWarning::PlayingError(PlayingError::BpmUndefined),
-            BmsWarning::PlayingError(PlayingError::NoNotes)
-        ]
+        playing_errors,
+        vec![PlayingError::BpmUndefined, PlayingError::NoNotes]
     );
 
     // Check header content - this file has minimal header info

--- a/tests/bms/mod.rs
+++ b/tests/bms/mod.rs
@@ -34,7 +34,7 @@ pub fn test_bms_assert_objs(src: &str, rng: impl Rng, expect_objs: impl AsRef<[W
     let ParseOutput {
         bms,
         parse_warnings,
-    } = Bms::from_token_stream::<'_, KeyLayoutBeat, _, _, _>(
+    } = Bms::from_token_stream(
         &tokens,
         default_config_with_rng(rng).prompter(AlwaysUseNewer),
     );

--- a/tests/bms/nested_random.rs
+++ b/tests/bms/nested_random.rs
@@ -47,25 +47,25 @@ fn nested_random() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                     .to_channel_id(),
                 wav_id: id55,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -78,19 +78,19 @@ fn nested_random() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(
+                channel_id: BmsLayoutBeat::new(
                     PlayerSide::Player1,
                     NoteKind::Visible,
                     Key::Scratch(1),
@@ -100,7 +100,7 @@ fn nested_random() {
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -113,19 +113,19 @@ fn nested_random() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                     .to_channel_id(),
                 wav_id: id33,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },

--- a/tests/bms/nested_switch.rs
+++ b/tests/bms/nested_switch.rs
@@ -122,25 +122,25 @@ fn nested_switch() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                     .to_channel_id(),
                 wav_id: id55,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -153,19 +153,19 @@ fn nested_switch() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(
+                channel_id: BmsLayoutBeat::new(
                     PlayerSide::Player1,
                     NoteKind::Visible,
                     Key::Scratch(1),
@@ -175,7 +175,7 @@ fn nested_switch() {
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -188,19 +188,19 @@ fn nested_switch() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                     .to_channel_id(),
                 wav_id: id33,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -252,25 +252,25 @@ fn nested_random_in_switch() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                     .to_channel_id(),
                 wav_id: id55,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -283,19 +283,19 @@ fn nested_random_in_switch() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(
+                channel_id: BmsLayoutBeat::new(
                     PlayerSide::Player1,
                     NoteKind::Visible,
                     Key::Scratch(1),
@@ -305,7 +305,7 @@ fn nested_random_in_switch() {
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -318,19 +318,19 @@ fn nested_random_in_switch() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                     .to_channel_id(),
                 wav_id: id33,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -382,25 +382,25 @@ fn nested_switch_in_random() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(5))
                     .to_channel_id(),
                 wav_id: id55,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("2 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -413,19 +413,19 @@ fn nested_switch_in_random() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 1, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(2))
                     .to_channel_id(),
                 wav_id: id22,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(
+                channel_id: BmsLayoutBeat::new(
                     PlayerSide::Player1,
                     NoteKind::Visible,
                     Key::Scratch(1),
@@ -435,7 +435,7 @@ fn nested_switch_in_random() {
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("2 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -448,19 +448,19 @@ fn nested_switch_in_random() {
         vec![
             WavObj {
                 offset: ObjTime::start_of(1.into()),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(1))
                     .to_channel_id(),
                 wav_id: id11,
             },
             WavObj {
                 offset: ObjTime::new(1, 2, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
                     .to_channel_id(),
                 wav_id: id33,
             },
             WavObj {
                 offset: ObjTime::new(1, 3, 4).expect("4 should be a valid denominator"),
-                channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
+                channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(4))
                     .to_channel_id(),
                 wav_id: id44,
             },
@@ -502,7 +502,7 @@ fn test_switch_insane() {
     ";
     let expected = vec![WavObj {
         offset: ObjTime::new(0, 1, 2).expect("2 should be a valid denominator"),
-        channel_id: KeyLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
+        channel_id: BmsLayoutBeat::new(PlayerSide::Player1, NoteKind::Visible, Key::Key(3))
             .to_channel_id(),
         wav_id: ObjId::try_from("55", false).unwrap(),
     }];

--- a/tests/bms/playing_conditions.rs
+++ b/tests/bms/playing_conditions.rs
@@ -20,7 +20,7 @@ fn test_playing_conditions_empty_bms() {
     let PlayingCheckOutput {
         playing_warnings,
         playing_errors,
-    } = bms.check_playing::<KeyLayoutBeat>();
+    } = bms.check_playing::<BmsLayoutBeat>();
 
     // Should have warnings and errors for empty BMS
     assert!(playing_warnings.contains(&PlayingWarning::TotalUndefined));
@@ -50,7 +50,7 @@ fn test_playing_conditions_with_bpm_and_notes() {
     let PlayingCheckOutput {
         playing_warnings,
         playing_errors,
-    } = bms.check_playing::<KeyLayoutBeat>();
+    } = bms.check_playing::<BmsLayoutBeat>();
 
     // Should not have any warnings or errors for valid BMS
     assert_eq!(playing_warnings, vec![]);
@@ -88,7 +88,7 @@ fn test_playing_conditions_with_bpm_change_only() {
     let PlayingCheckOutput {
         playing_warnings,
         playing_errors,
-    } = bms.check_playing::<KeyLayoutBeat>();
+    } = bms.check_playing::<BmsLayoutBeat>();
 
     // Should have StartBpmUndefined warning but no BpmUndefined error
     assert_eq!(bms.bpm.bpm, None);
@@ -119,7 +119,7 @@ fn test_playing_conditions_invisible_notes_only() {
     let PlayingCheckOutput {
         playing_warnings,
         playing_errors,
-    } = bms.check_playing::<KeyLayoutBeat>();
+    } = bms.check_playing::<BmsLayoutBeat>();
 
     // Should have both NoDisplayableNotes and NoPlayableNotes warnings
     assert!(playing_warnings.contains(&PlayingWarning::NoDisplayableNotes));

--- a/tests/bms/prelude_test.rs
+++ b/tests/bms/prelude_test.rs
@@ -78,19 +78,3 @@ fn test_prelude_minor_command_imports() {
     assert_eq!(*_ex_wav_volume.as_ref(), 0);
     assert_eq!(u64::from(_ex_wav_frequency), 100);
 }
-
-#[test]
-#[cfg(feature = "diagnostics")]
-fn test_prelude_diagnostics_imports() {
-    let _simple_source = SimpleSource::new("test.bms", "#TITLE Test");
-    let _bms_warning = BmsWarning::PlayingWarning(PlayingWarning::TotalUndefined);
-
-    let source_text = "#TITLE Test\n#ARTIST Composer\n";
-    let source = SimpleSource::new("test.bms", source_text);
-    let warnings = vec![BmsWarning::PlayingWarning(PlayingWarning::TotalUndefined)];
-
-    let reports = bms_rs::diagnostics::collect_bms_reports("test.bms", source_text, &warnings);
-    assert_eq!(reports.len(), warnings.len());
-
-    let _report = _bms_warning.to_report(&source);
-}

--- a/tests/bms/unparse_merge.rs
+++ b/tests/bms/unparse_merge.rs
@@ -57,7 +57,7 @@ fn test_scenario_1_no_merge() {
     let bms = bms.unwrap();
 
     // Unparse back to tokens
-    let unparsed_tokens = bms.unparse::<KeyLayoutBeat>();
+    let unparsed_tokens = bms.unparse();
 
     // Expected tokens - messages with same track/channel are merged, others remain separate (based on actual unparse behavior)
     let expected_tokens = [
@@ -137,7 +137,7 @@ fn test_scenario_2_can_merge() {
     let bms = bms.unwrap();
 
     // Unparse back to tokens
-    let unparsed_tokens = bms.unparse::<KeyLayoutBeat>();
+    let unparsed_tokens = bms.unparse();
 
     // Expected tokens - messages are merged as per actual unparse behavior
     let expected_tokens = [
@@ -214,7 +214,7 @@ fn test_scenario_3_cross_track_no_merge() {
     let bms = bms.unwrap();
 
     // Unparse back to tokens
-    let unparsed_tokens = bms.unparse::<KeyLayoutBeat>();
+    let unparsed_tokens = bms.unparse();
 
     // Expected tokens - messages are merged as per actual unparse behavior
     let expected_tokens = [
@@ -286,7 +286,7 @@ fn test_scenario_4_input_order_preservation() {
     let bms = bms.unwrap();
 
     // Unparse back to tokens
-    let unparsed_tokens = bms.unparse::<KeyLayoutBeat>();
+    let unparsed_tokens = bms.unparse();
 
     // Expected tokens - FF remains first, AA and BB are merged together (based on actual unparse behavior)
     let expected_tokens = [

--- a/tests/bms/unparse_roundtrip.rs
+++ b/tests/bms/unparse_roundtrip.rs
@@ -94,7 +94,7 @@ fn roundtrip_source_bms_tokens_bms(source: &str) {
     };
 
     // Bms -> tokens (unparse)
-    let tokens2 = bms1.unparse::<KeyLayoutBeat>();
+    let tokens2 = bms1.unparse();
     let tokens2_wrapped: Vec<TokenWithRange<'_>> = tokens2
         .into_iter()
         .map(|t| SourceRangeMixin::new(t, 0..0))

--- a/tests/chart/bms/chart.rs
+++ b/tests/chart/bms/chart.rs
@@ -1,6 +1,5 @@
 use gametime::{TimeSpan, TimeStamp};
 
-use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
 use bms_rs::bms::prelude::*;
 use strict_num_extended::PositiveF64;
 
@@ -8,6 +7,7 @@ use strict_num_extended::PositiveF64;
 const DEFAULT_BPM_120: PositiveF64 = PositiveF64::new_const(120.0);
 
 use bms_rs::chart::prelude::*;
+use bms_rs::chart::process::Process;
 
 use super::parse_bms_no_warnings;
 
@@ -29,7 +29,7 @@ fn test_bms_events_in_time_range_returns_note_near_center() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(DEFAULT_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::start();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _events = processor.update(start_time + TimeSpan::SECOND * 2);
@@ -69,7 +69,7 @@ fn test_parsed_chart_tracks_have_correct_y_coordinates_and_wav_ids() {
     let config = default_config().prompter(AlwaysUseNewer);
     let bms = parse_bms_no_warnings(bms_source, config);
 
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
 
     let note_events: Vec<_> = chart
         .events()

--- a/tests/chart/bms/mod.rs
+++ b/tests/chart/bms/mod.rs
@@ -14,9 +14,8 @@ use super::{MICROSECOND_EPSILON, assert_time_close};
 /// # Panics
 ///
 /// Panics if there are any lex or parse warnings.
-pub fn parse_bms_no_warnings<T, P, R, M>(source: &str, config: ParseConfig<T, P, R, M>) -> Bms
+pub fn parse_bms_no_warnings<P, R, M>(source: &str, config: ParseConfig<P, R, M>) -> Bms
 where
-    T: KeyLayoutMapper,
     P: Prompter,
     R: Rng,
     M: TokenModifier,

--- a/tests/chart/bms/playback_state.rs
+++ b/tests/chart/bms/playback_state.rs
@@ -1,10 +1,10 @@
 use gametime::{TimeSpan, TimeStamp};
 
-use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
 use bms_rs::bms::prelude::*;
 use strict_num_extended::{FinF64, PositiveF64};
 
 use bms_rs::chart::prelude::*;
+use bms_rs::chart::process::Process;
 
 use super::{MICROSECOND_EPSILON, assert_time_close, parse_bms_no_warnings};
 
@@ -21,7 +21,7 @@ fn test_bms_triggered_event_activate_time_equals_elapsed() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -67,7 +67,7 @@ fn test_bms_restart_resets_scroll_to_one() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -83,7 +83,7 @@ fn test_bms_restart_resets_scroll_to_one() {
         .generate(&bms2)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm2 = VisibleRangePerBpm::new(base_bpm2.value(), reaction_time);
-    let chart2 = BmsProcessor::parse::<KeyLayoutBeat>(&bms2).expect("failed to parse chart");
+    let chart2 = bms2.process().expect("failed to parse chart");
     let start_time2 = TimeStamp::now();
     let restarted_processor = ChartPlayer::start(&chart2, visible_range_per_bpm2, start_time2);
     let reset_state = restarted_processor.playback_state();
@@ -111,7 +111,7 @@ fn test_visible_events_duration_matches_reaction_time() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bms/section.rs
+++ b/tests/chart/bms/section.rs
@@ -1,10 +1,10 @@
 use gametime::{TimeSpan, TimeStamp};
 
-use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
 use bms_rs::bms::prelude::*;
 use strict_num_extended::PositiveF64;
 
 use bms_rs::chart::prelude::*;
+use bms_rs::chart::process::Process;
 
 use super::parse_bms_no_warnings;
 
@@ -93,7 +93,7 @@ fn test_bms_zero_length_section_comprehensive() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
 
     assert!(
         !chart.events().as_events().is_empty(),
@@ -150,7 +150,7 @@ fn test_bms_very_small_section_no_division_by_zero() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -234,7 +234,7 @@ fn test_bms_consecutive_zero_length_sections() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bms/visible_events.rs
+++ b/tests/chart/bms/visible_events.rs
@@ -2,11 +2,11 @@ use std::str::FromStr;
 
 use gametime::{TimeSpan, TimeStamp};
 
-use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
 use bms_rs::bms::prelude::*;
 use strict_num_extended::{FinF64, PositiveF64};
 
 use bms_rs::chart::prelude::*;
+use bms_rs::chart::process::Process;
 
 use super::{assert_time_close, parse_bms_no_warnings};
 
@@ -23,7 +23,7 @@ fn test_bemuse_ext_basic_visible_events_functionality() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -100,7 +100,7 @@ fn test_bms_visible_event_activate_time_within_reaction_window() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -131,7 +131,7 @@ fn test_lilith_mx_bpm_changes_affect_visible_window() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -195,7 +195,7 @@ fn test_bemuse_ext_scroll_half_display_ratio_scaling() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -302,7 +302,7 @@ fn test_bms_multi_flow_events_same_y_all_triggered() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -392,7 +392,7 @@ fn test_custom_visibility_range() {
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm =
         VisibleRangePerBpm::new(base_bpm.value(), TimeSpan::MILLISECOND * 600);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut player = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -436,7 +436,7 @@ fn test_visibility_range_bound_types() {
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm =
         VisibleRangePerBpm::new(base_bpm.value(), TimeSpan::MILLISECOND * 600);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = bms.process().expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut player = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bmson/activate_time.rs
+++ b/tests/chart/bmson/activate_time.rs
@@ -3,8 +3,8 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
+use bms_rs::chart::process::Process;
 
 use super::assert_time_close;
 
@@ -33,7 +33,7 @@ fn test_bmson_visible_event_activate_time_prediction() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -79,7 +79,7 @@ fn test_bmson_visible_event_activate_time_with_bpm_change() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _ = processor.update(start_time);
@@ -125,7 +125,7 @@ fn test_bmson_visible_event_activate_time_with_stop_inside_interval() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _ = processor.update(start_time);

--- a/tests/chart/bmson/chart.rs
+++ b/tests/chart/bmson/chart.rs
@@ -3,8 +3,8 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
+use bms_rs::chart::process::Process;
 
 fn assert_playback_state_equal(state1: &PlaybackState, state2: &PlaybackState) {
     // Use approximate comparison to handle floating-point precision issues
@@ -160,7 +160,7 @@ fn test_bmson_events_in_time_range_returns_note_near_center() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let processor_start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, processor_start_time);
     let start_time = TimeStamp::start();
@@ -220,7 +220,7 @@ fn test_update_consistency_extreme_many_intervals() {
     let base_bpm = StartBpmGenerator
         .generate(&bmson)
         .expect("Failed to generate base BPM");
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let visible_range = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
 
     let start_time = TimeStamp::start();
@@ -315,7 +315,7 @@ fn test_update_consistency_zero_interval() {
     let base_bpm = StartBpmGenerator
         .generate(&bmson)
         .expect("Failed to generate base BPM");
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let visible_range = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
 
     let mut player = ChartPlayer::start(&chart, visible_range, TimeStamp::start());

--- a/tests/chart/bmson/continue_time.rs
+++ b/tests/chart/bmson/continue_time.rs
@@ -3,8 +3,8 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
+use bms_rs::chart::process::Process;
 
 use super::{MICROSECOND_EPSILON, assert_time_close};
 
@@ -41,7 +41,7 @@ fn test_bmson_continue_duration_references_bpm_and_stop() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -103,7 +103,7 @@ fn test_bmson_continue_duration_with_bpm_scroll_and_stop() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -159,7 +159,7 @@ fn test_bmson_multiple_continue_and_noncontinue_in_same_channel() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -232,7 +232,7 @@ fn test_bmson_continue_accumulates_multiple_stops_between_notes() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -297,7 +297,7 @@ fn test_bmson_continue_independent_across_sound_channels() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let t = start_time + TimeSpan::MILLISECOND * 100;

--- a/tests/chart/bmson/playback_state.rs
+++ b/tests/chart/bmson/playback_state.rs
@@ -3,8 +3,8 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
+use bms_rs::chart::process::Process;
 use strict_num_extended::{FinF64, PositiveF64};
 
 use super::assert_time_close;
@@ -42,7 +42,7 @@ fn test_bmson_restart_resets_scroll_to_one() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let processor_start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, processor_start_time);
     let start_time = processor.started_at();
@@ -59,7 +59,7 @@ fn test_bmson_restart_resets_scroll_to_one() {
         .generate(&bmson2)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm2 = VisibleRangePerBpm::new(base_bpm2.value(), reaction_time);
-    let chart2 = BmsonProcessor::parse(&bmson2);
+    let chart2 = bmson2.process().expect("Failed to process BMSON");
     let start_time2 = TimeStamp::now();
     let restarted_processor = ChartPlayer::start(&chart2, visible_range_per_bpm2, start_time2);
     let reset_state = restarted_processor.playback_state();
@@ -104,7 +104,7 @@ fn test_bmson_edge_cases_no_division_by_zero() {
         );
     };
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::start();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -173,7 +173,7 @@ fn test_very_long_elapsed_time_no_errors() {
     };
 
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::start();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bmson/visible_events.rs
+++ b/tests/chart/bmson/visible_events.rs
@@ -3,8 +3,8 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
+use bms_rs::chart::process::Process;
 use strict_num_extended::{FinF64, PositiveF64};
 
 use super::assert_time_close;
@@ -41,7 +41,7 @@ fn test_bmson_visible_events_display_ratio_is_not_all_zero() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::start();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -87,7 +87,7 @@ fn test_visible_events_duration_matches_reaction_time() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _start_time = TimeStamp::start();
@@ -137,7 +137,7 @@ fn test_visible_events_duration_with_playback_ratio() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _start_time = TimeStamp::start();
@@ -204,7 +204,7 @@ fn test_visible_events_with_boundary_conditions() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().expect("Failed to process BMSON");
     let start_time = TimeStamp::now();
     let _processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 


### PR DESCRIPTION
- Rename KeyLayout* -> BmsLayout*, KeyMapping -> BmsLayout, KeyLayoutMapper -> BmsLayoutMapper
- Remove generic T (key mapper) from ParseConfig, Bms::unparse, WavProcessor, BmsProcessor, and Notes iter methods
- Move check_playing method from parse module to Bms model, decouple from parse_bms pipeline
- Add NoteChannelId helpers: is_bgm(), is_visible_note_channel(), to_long_note_channel()
- Make BmsProcessor private (no longer pub struct/pub fn parse)