### PR TITLE
refactor: unify parsing API under Process trait, hide processor internals

### DIFF
--- a/benches/parse_bms.rs
+++ b/benches/parse_bms.rs
@@ -1,7 +1,6 @@
 //! Benchmark for `BMS` file parsing and chart conversion.
 
 use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
-use bms_rs::bms::model::Bms;
 use bms_rs::bms::{default_config, parse_bms};
 use bms_rs::chart::prelude::Process;
 use criterion::{Criterion, Throughput};
@@ -80,7 +79,7 @@ fn bench_bms_to_chart(c: &mut Criterion) {
 
     for (name, chart) in PARSED_CHARTS.iter() {
         group.bench_function(name, |b| {
-            b.iter(|| <Bms as Process<KeyLayoutBeat>>::process(std::hint::black_box(chart)));
+            b.iter(|| Process::<KeyLayoutBeat>::process(std::hint::black_box(chart)));
         });
     }
 

--- a/benches/parse_bms.rs
+++ b/benches/parse_bms.rs
@@ -1,8 +1,9 @@
 //! Benchmark for `BMS` file parsing and chart conversion.
 
-use bms_rs::bms::{
-    command::channel::mapper::KeyLayoutBeat, default_config, parse_bms, process::BmsProcessor,
-};
+use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
+use bms_rs::bms::model::Bms;
+use bms_rs::bms::{default_config, parse_bms};
+use bms_rs::chart::prelude::Process;
 use criterion::{Criterion, Throughput};
 use std::{collections::BTreeMap, sync::LazyLock};
 
@@ -79,7 +80,7 @@ fn bench_bms_to_chart(c: &mut Criterion) {
 
     for (name, chart) in PARSED_CHARTS.iter() {
         group.bench_function(name, |b| {
-            b.iter(|| BmsProcessor::parse::<KeyLayoutBeat>(std::hint::black_box(chart)));
+            b.iter(|| <Bms as Process<KeyLayoutBeat>>::process(std::hint::black_box(chart)));
         });
     }
 

--- a/benches/parse_bmson.rs
+++ b/benches/parse_bmson.rs
@@ -1,6 +1,7 @@
 //! Benchmark for `BMSON` file parsing and chart conversion.
 
-use bms_rs::bmson::{Bmson, parse_bmson, process::BmsonProcessor};
+use bms_rs::bmson::{Bmson, parse_bmson};
+use bms_rs::chart::prelude::Process;
 use criterion::{Criterion, Throughput};
 use std::{collections::BTreeMap, sync::LazyLock};
 
@@ -74,7 +75,7 @@ fn bench_bmson_to_chart(c: &mut Criterion) {
 
     for (name, chart) in PARSED_CHARTS.iter() {
         group.bench_function(name, |b| {
-            b.iter(|| BmsonProcessor::parse(std::hint::black_box(chart)));
+            b.iter(|| std::hint::black_box(chart).process().unwrap());
         });
     }
 

--- a/examples/microquad_player.rs
+++ b/examples/microquad_player.rs
@@ -215,7 +215,7 @@ fn load_chart(path: &Path) -> Result<(Chart, BaseBpm), String> {
                 .generate(&bms)
                 .unwrap_or(BaseBpm::new(DEFAULT_BPM));
 
-            let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms)
+            let chart = Process::<KeyLayoutBeat>::process(&bms)
                 .map_err(|e| format!("Failed to parse chart: {e}"))?;
             (chart, base_bpm)
         }

--- a/examples/microquad_player.rs
+++ b/examples/microquad_player.rs
@@ -8,7 +8,6 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use bms_rs::bms::prelude::*;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 use clap::Parser;
 use gametime::{TimeSpan, TimeStamp};
@@ -207,7 +206,7 @@ fn load_chart(path: &Path) -> Result<(Chart, BaseBpm), String> {
 
     let (chart, base_bpm) = match extension.to_lowercase().as_str() {
         "bms" | "bme" | "bml" | "pms" => {
-            // Parse using BmsProcessor
+            // Parse using Process trait
             let output = parse_bms(&content, default_config());
             let bms = output.bms.map_err(|e| format!("Parse error: {e:?}"))?;
 
@@ -216,8 +215,7 @@ fn load_chart(path: &Path) -> Result<(Chart, BaseBpm), String> {
                 .generate(&bms)
                 .unwrap_or(BaseBpm::new(DEFAULT_BPM));
 
-            // Use KeyLayoutBeat mapper (supports 7+1k)
-            let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms)
+            let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms)
                 .map_err(|e| format!("Failed to parse chart: {e}"))?;
             (chart, base_bpm)
         }
@@ -225,7 +223,7 @@ fn load_chart(path: &Path) -> Result<(Chart, BaseBpm), String> {
             // BMSON format
             #[cfg(feature = "bmson")]
             {
-                let bmson =
+                let bmson: bms_rs::bmson::Bmson<'_> =
                     serde_json::from_str(&content).map_err(|e| format!("JSON parse error: {e}"))?;
 
                 // First generate base BPM from BMSON
@@ -233,7 +231,7 @@ fn load_chart(path: &Path) -> Result<(Chart, BaseBpm), String> {
                     .generate(&bmson)
                     .unwrap_or(BaseBpm::new(DEFAULT_BPM));
 
-                let chart = BmsonProcessor::parse(&bmson);
+                let chart = bmson.process().unwrap();
                 (chart, base_bpm)
             }
             #[cfg(not(feature = "bmson"))]

--- a/src/bms/prelude.rs
+++ b/src/bms/prelude.rs
@@ -69,8 +69,8 @@ pub use super::{
     rng::{Rng, RngMock},
 };
 
-// Re-export process module
-pub use super::process::BmsProcessor;
+// Re-export chart process trait
+pub use crate::chart::process::Process;
 
 // Re-export chart event types (including BmsEvent)
 pub use crate::chart::event::BmsEvent;

--- a/src/bms/process.rs
+++ b/src/bms/process.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    convert::TryFrom,
     path::PathBuf,
 };
 
@@ -21,11 +20,13 @@ use crate::chart::process::{
 use crate::chart::{Chart, DEFAULT_BPM, DEFAULT_SPEED, MAX_FIN_F64, MAX_NON_NEGATIVE_F64};
 use strict_num_extended::NonNegativeF64;
 
-/// BMS format parser.
+/// BMS format parser (internal).
 ///
 /// This struct serves as a namespace for BMS parsing functions.
 /// It parses BMS files and returns a `Chart` containing all precomputed data.
-pub struct BmsProcessor;
+///
+/// Users should use [`Bms::process`](Process) via the [`Process`] trait instead.
+struct BmsProcessor;
 
 /// Convert STOP duration from 192nd-note units to beats (measure units).
 ///
@@ -156,7 +157,7 @@ impl BmsProcessor {
     }
 
     /// Generate measure lines for BMS (generated for each track, but not exceeding other objects' Y values)
-    pub fn generate_barlines_for_bms(
+    pub(crate) fn generate_barlines_for_bms(
         bms: &Bms,
         y_memo: &YMemo,
         events_map: &mut BTreeMap<YCoordinate, Vec<PlayheadEvent>>,
@@ -197,6 +198,14 @@ impl BmsProcessor {
         let key = map.key();
         let kind = map.kind();
         Some((side, key, kind))
+    }
+}
+
+impl<L: KeyLayoutMapper> Process<L> for Bms {
+    type Error = PlayingError;
+
+    fn process(&self) -> Result<Chart, Self::Error> {
+        BmsProcessor::parse::<L>(self)
     }
 }
 
@@ -797,22 +806,6 @@ pub fn event_for_note_static<T: KeyLayoutMapper>(
         wav_id,
         length,
         continue_play: None,
-    }
-}
-
-impl TryFrom<Bms> for Chart {
-    type Error = PlayingError;
-
-    fn try_from(bms: Bms) -> Result<Self, Self::Error> {
-        BmsProcessor::parse::<KeyLayoutBeat>(&bms)
-    }
-}
-
-impl Process for Bms {
-    type Error = PlayingError;
-
-    fn process(&self) -> Result<Chart, Self::Error> {
-        BmsProcessor::parse::<KeyLayoutBeat>(self)
     }
 }
 

--- a/src/bms/process.rs
+++ b/src/bms/process.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use strict_num_extended::{FinF64, PositiveF64};
+use strict_num_extended::{FinF64, NonNegativeF64, PositiveF64};
 
 use crate::bms::command::string_value::StringValue;
 use crate::bms::parse::check_playing::PlayingError;
@@ -18,7 +18,6 @@ use crate::chart::process::{
     calculate_cumulative_times,
 };
 use crate::chart::{Chart, DEFAULT_BPM, DEFAULT_SPEED, MAX_FIN_F64, MAX_NON_NEGATIVE_F64};
-use strict_num_extended::NonNegativeF64;
 
 /// BMS format parser (internal).
 ///

--- a/src/bmson/prelude.rs
+++ b/src/bmson/prelude.rs
@@ -32,5 +32,5 @@ pub use super::{default_mode_hint, default_percentage, default_resolution};
 // Re-export BMS types that are dependencies of BMSON types
 pub use crate::bms::command::LnMode;
 
-// Re-export process module
-pub use super::process::BmsonProcessor;
+// Re-export chart process trait
+pub use crate::chart::process::Process;

--- a/src/bmson/process.rs
+++ b/src/bmson/process.rs
@@ -3,7 +3,6 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    convert::TryFrom,
     path::PathBuf,
 };
 
@@ -21,11 +20,13 @@ use crate::chart::types::{BgaLayer, Key, NoteKind, PlayerSide};
 use crate::chart::{Chart, DEFAULT_SPEED, MAX_FIN_F64, MAX_NON_NEGATIVE_F64};
 use crate::util::StrExtension;
 
-/// BMSON format parser.
+/// BMSON format parser (internal).
 ///
 /// This struct serves as a namespace for BMSON parsing functions.
 /// It parses BMSON files and returns a `Chart` containing all precomputed data.
-pub struct BmsonProcessor;
+///
+/// Users should use [`Bmson::process`](Process) via the [`Process`] trait instead.
+struct BmsonProcessor;
 
 impl BmsonProcessor {
     /// Parse BMSON file and return a `Chart` containing all precomputed data.
@@ -435,16 +436,8 @@ impl AllEventsIndex {
     }
 }
 
-impl<'a> TryFrom<Bmson<'a>> for Chart {
-    type Error = ();
-
-    fn try_from(bmson: Bmson<'a>) -> Result<Self, Self::Error> {
-        Ok(BmsonProcessor::parse(&bmson))
-    }
-}
-
 impl Process for Bmson<'_> {
-    type Error = ();
+    type Error = std::convert::Infallible;
 
     fn process(&self) -> Result<Chart, Self::Error> {
         Ok(BmsonProcessor::parse(self))

--- a/src/chart/player.rs
+++ b/src/chart/player.rs
@@ -66,7 +66,7 @@ impl<'a> ChartPlayer<'a> {
     /// let start_time = TimeStamp::now();
     /// let base_bpm = StartBpmGenerator.generate(&bms)?;
     /// let visible_range = VisibleRangePerBpm::new(base_bpm, reaction_time);
-    /// let chart = BmsProcessor::parse(&bms);
+    ///     let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms);
     ///
     /// let mut player = ChartPlayer::start(&chart, visible_range, start_time);
     /// ```

--- a/src/chart/player.rs
+++ b/src/chart/player.rs
@@ -66,7 +66,7 @@ impl<'a> ChartPlayer<'a> {
     /// let start_time = TimeStamp::now();
     /// let base_bpm = StartBpmGenerator.generate(&bms)?;
     /// let visible_range = VisibleRangePerBpm::new(base_bpm, reaction_time);
-    ///     let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms);
+    /// let chart = Process::<KeyLayoutBeat>::process(&bms);
     ///
     /// let mut player = ChartPlayer::start(&chart, visible_range, start_time);
     /// ```

--- a/src/chart/process.rs
+++ b/src/chart/process.rs
@@ -12,7 +12,11 @@ use strict_num_extended::NonNegativeF64;
 use strict_num_extended::PositiveF64;
 
 /// Trait for types that can be processed into a `Chart`. It's intended that chart types implement this.
-pub trait Process {
+///
+/// The type parameter `L` is a phantom parameter used to constrain which types can be processed
+/// into a chart. For example, `Bms` requires `L: KeyLayoutMapper` to specify the key layout,
+/// while `Bmson` uses the default `L = ()`.
+pub trait Process<L = ()> {
     /// Error type returned when processing fails.
     type Error;
 

--- a/src/chart/process.rs
+++ b/src/chart/process.rs
@@ -8,8 +8,7 @@ use std::path::PathBuf;
 use crate::chart::event::{ChartEvent, PlayheadEvent, YCoordinate};
 use crate::chart::types::NoteKind;
 use crate::chart::{Chart, TimeSpan};
-use strict_num_extended::NonNegativeF64;
-use strict_num_extended::PositiveF64;
+use strict_num_extended::{NonNegativeF64, PositiveF64};
 
 /// Trait for types that can be processed into a `Chart`. It's intended that chart types implement this.
 ///

--- a/tests/chart/bms/chart.rs
+++ b/tests/chart/bms/chart.rs
@@ -1,6 +1,5 @@
 use gametime::{TimeSpan, TimeStamp};
 
-use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
 use bms_rs::bms::prelude::*;
 use strict_num_extended::PositiveF64;
 
@@ -29,7 +28,7 @@ fn test_bms_events_in_time_range_returns_note_near_center() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(DEFAULT_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::start();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _events = processor.update(start_time + TimeSpan::SECOND * 2);
@@ -69,7 +68,7 @@ fn test_parsed_chart_tracks_have_correct_y_coordinates_and_wav_ids() {
     let config = default_config().prompter(AlwaysUseNewer);
     let bms = parse_bms_no_warnings(bms_source, config);
 
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
 
     let note_events: Vec<_> = chart
         .events()

--- a/tests/chart/bms/chart.rs
+++ b/tests/chart/bms/chart.rs
@@ -28,7 +28,7 @@ fn test_bms_events_in_time_range_returns_note_near_center() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(DEFAULT_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::start();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _events = processor.update(start_time + TimeSpan::SECOND * 2);
@@ -68,7 +68,7 @@ fn test_parsed_chart_tracks_have_correct_y_coordinates_and_wav_ids() {
     let config = default_config().prompter(AlwaysUseNewer);
     let bms = parse_bms_no_warnings(bms_source, config);
 
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
 
     let note_events: Vec<_> = chart
         .events()

--- a/tests/chart/bms/mod.rs
+++ b/tests/chart/bms/mod.rs
@@ -1,4 +1,4 @@
-//! Integration tests for `bms_rs::chart::BmsProcessor`.
+//! Integration tests for `bms_rs::bms::process` (Process trait on Bms).
 
 mod chart;
 mod playback_state;

--- a/tests/chart/bms/playback_state.rs
+++ b/tests/chart/bms/playback_state.rs
@@ -20,7 +20,7 @@ fn test_bms_triggered_event_activate_time_equals_elapsed() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -66,7 +66,7 @@ fn test_bms_restart_resets_scroll_to_one() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -82,7 +82,7 @@ fn test_bms_restart_resets_scroll_to_one() {
         .generate(&bms2)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm2 = VisibleRangePerBpm::new(base_bpm2.value(), reaction_time);
-    let chart2 = <Bms as Process<KeyLayoutBeat>>::process(&bms2).expect("failed to parse chart");
+    let chart2 = Process::<KeyLayoutBeat>::process(&bms2).expect("failed to parse chart");
     let start_time2 = TimeStamp::now();
     let restarted_processor = ChartPlayer::start(&chart2, visible_range_per_bpm2, start_time2);
     let reset_state = restarted_processor.playback_state();
@@ -110,7 +110,7 @@ fn test_visible_events_duration_matches_reaction_time() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bms/playback_state.rs
+++ b/tests/chart/bms/playback_state.rs
@@ -1,6 +1,5 @@
 use gametime::{TimeSpan, TimeStamp};
 
-use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
 use bms_rs::bms::prelude::*;
 use strict_num_extended::{FinF64, PositiveF64};
 
@@ -21,7 +20,7 @@ fn test_bms_triggered_event_activate_time_equals_elapsed() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -67,7 +66,7 @@ fn test_bms_restart_resets_scroll_to_one() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -83,7 +82,7 @@ fn test_bms_restart_resets_scroll_to_one() {
         .generate(&bms2)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm2 = VisibleRangePerBpm::new(base_bpm2.value(), reaction_time);
-    let chart2 = BmsProcessor::parse::<KeyLayoutBeat>(&bms2).expect("failed to parse chart");
+    let chart2 = <Bms as Process<KeyLayoutBeat>>::process(&bms2).expect("failed to parse chart");
     let start_time2 = TimeStamp::now();
     let restarted_processor = ChartPlayer::start(&chart2, visible_range_per_bpm2, start_time2);
     let reset_state = restarted_processor.playback_state();
@@ -111,7 +110,7 @@ fn test_visible_events_duration_matches_reaction_time() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bms/section.rs
+++ b/tests/chart/bms/section.rs
@@ -1,6 +1,5 @@
 use gametime::{TimeSpan, TimeStamp};
 
-use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
 use bms_rs::bms::prelude::*;
 use strict_num_extended::PositiveF64;
 
@@ -93,7 +92,7 @@ fn test_bms_zero_length_section_comprehensive() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
 
     assert!(
         !chart.events().as_events().is_empty(),
@@ -150,7 +149,7 @@ fn test_bms_very_small_section_no_division_by_zero() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -234,7 +233,7 @@ fn test_bms_consecutive_zero_length_sections() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bms/section.rs
+++ b/tests/chart/bms/section.rs
@@ -92,7 +92,7 @@ fn test_bms_zero_length_section_comprehensive() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
 
     assert!(
         !chart.events().as_events().is_empty(),
@@ -149,7 +149,7 @@ fn test_bms_very_small_section_no_division_by_zero() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -233,7 +233,7 @@ fn test_bms_consecutive_zero_length_sections() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bms/visible_events.rs
+++ b/tests/chart/bms/visible_events.rs
@@ -22,7 +22,7 @@ fn test_bemuse_ext_basic_visible_events_functionality() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -99,7 +99,7 @@ fn test_bms_visible_event_activate_time_within_reaction_window() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -130,7 +130,7 @@ fn test_lilith_mx_bpm_changes_affect_visible_window() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -194,7 +194,7 @@ fn test_bemuse_ext_scroll_half_display_ratio_scaling() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -301,7 +301,7 @@ fn test_bms_multi_flow_events_same_y_all_triggered() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -391,7 +391,7 @@ fn test_custom_visibility_range() {
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm =
         VisibleRangePerBpm::new(base_bpm.value(), TimeSpan::MILLISECOND * 600);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut player = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -435,7 +435,7 @@ fn test_visibility_range_bound_types() {
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm =
         VisibleRangePerBpm::new(base_bpm.value(), TimeSpan::MILLISECOND * 600);
-    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
+    let chart = Process::<KeyLayoutBeat>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut player = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bms/visible_events.rs
+++ b/tests/chart/bms/visible_events.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use gametime::{TimeSpan, TimeStamp};
 
-use bms_rs::bms::command::channel::mapper::KeyLayoutBeat;
 use bms_rs::bms::prelude::*;
 use strict_num_extended::{FinF64, PositiveF64};
 
@@ -23,7 +22,7 @@ fn test_bemuse_ext_basic_visible_events_functionality() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -100,7 +99,7 @@ fn test_bms_visible_event_activate_time_within_reaction_window() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -131,7 +130,7 @@ fn test_lilith_mx_bpm_changes_affect_visible_window() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -195,7 +194,7 @@ fn test_bemuse_ext_scroll_half_display_ratio_scaling() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -302,7 +301,7 @@ fn test_bms_multi_flow_events_same_y_all_triggered() {
         .generate(&bms)
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -392,7 +391,7 @@ fn test_custom_visibility_range() {
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm =
         VisibleRangePerBpm::new(base_bpm.value(), TimeSpan::MILLISECOND * 600);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut player = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -436,7 +435,7 @@ fn test_visibility_range_bound_types() {
         .unwrap_or(BaseBpm::new(TEST_BPM_120));
     let visible_range_per_bpm =
         VisibleRangePerBpm::new(base_bpm.value(), TimeSpan::MILLISECOND * 600);
-    let chart = BmsProcessor::parse::<KeyLayoutBeat>(&bms).expect("failed to parse chart");
+    let chart = <Bms as Process<KeyLayoutBeat>>::process(&bms).expect("failed to parse chart");
     let start_time = TimeStamp::now();
     let mut player = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bmson/activate_time.rs
+++ b/tests/chart/bmson/activate_time.rs
@@ -3,7 +3,6 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 
 use super::assert_time_close;
@@ -33,7 +32,7 @@ fn test_bmson_visible_event_activate_time_prediction() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -79,7 +78,7 @@ fn test_bmson_visible_event_activate_time_with_bpm_change() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _ = processor.update(start_time);
@@ -125,7 +124,7 @@ fn test_bmson_visible_event_activate_time_with_stop_inside_interval() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _ = processor.update(start_time);

--- a/tests/chart/bmson/chart.rs
+++ b/tests/chart/bmson/chart.rs
@@ -3,7 +3,6 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 
 fn assert_playback_state_equal(state1: &PlaybackState, state2: &PlaybackState) {
@@ -160,7 +159,7 @@ fn test_bmson_events_in_time_range_returns_note_near_center() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let processor_start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, processor_start_time);
     let start_time = TimeStamp::start();
@@ -220,7 +219,7 @@ fn test_update_consistency_extreme_many_intervals() {
     let base_bpm = StartBpmGenerator
         .generate(&bmson)
         .expect("Failed to generate base BPM");
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let visible_range = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
 
     let start_time = TimeStamp::start();
@@ -315,7 +314,7 @@ fn test_update_consistency_zero_interval() {
     let base_bpm = StartBpmGenerator
         .generate(&bmson)
         .expect("Failed to generate base BPM");
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let visible_range = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
 
     let mut player = ChartPlayer::start(&chart, visible_range, TimeStamp::start());

--- a/tests/chart/bmson/continue_time.rs
+++ b/tests/chart/bmson/continue_time.rs
@@ -3,7 +3,6 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 
 use super::{MICROSECOND_EPSILON, assert_time_close};
@@ -41,7 +40,7 @@ fn test_bmson_continue_duration_references_bpm_and_stop() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -103,7 +102,7 @@ fn test_bmson_continue_duration_with_bpm_scroll_and_stop() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -159,7 +158,7 @@ fn test_bmson_multiple_continue_and_noncontinue_in_same_channel() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -232,7 +231,7 @@ fn test_bmson_continue_accumulates_multiple_stops_between_notes() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -297,7 +296,7 @@ fn test_bmson_continue_independent_across_sound_channels() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let t = start_time + TimeSpan::MILLISECOND * 100;

--- a/tests/chart/bmson/mod.rs
+++ b/tests/chart/bmson/mod.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "bmson")]
 
-//! Integration tests for `bms_rs::chart::BmsonProcessor`.
+//! Integration tests for `bms_rs::bmson::process` (Process trait on Bmson).
 
 mod activate_time;
 mod chart;

--- a/tests/chart/bmson/playback_state.rs
+++ b/tests/chart/bmson/playback_state.rs
@@ -3,7 +3,6 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 use strict_num_extended::{FinF64, PositiveF64};
 
@@ -42,7 +41,7 @@ fn test_bmson_restart_resets_scroll_to_one() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let processor_start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, processor_start_time);
     let start_time = processor.started_at();
@@ -59,7 +58,7 @@ fn test_bmson_restart_resets_scroll_to_one() {
         .generate(&bmson2)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm2 = VisibleRangePerBpm::new(base_bpm2.value(), reaction_time);
-    let chart2 = BmsonProcessor::parse(&bmson2);
+    let chart2 = bmson2.process().unwrap();
     let start_time2 = TimeStamp::now();
     let restarted_processor = ChartPlayer::start(&chart2, visible_range_per_bpm2, start_time2);
     let reset_state = restarted_processor.playback_state();
@@ -104,7 +103,7 @@ fn test_bmson_edge_cases_no_division_by_zero() {
         );
     };
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::start();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -173,7 +172,7 @@ fn test_very_long_elapsed_time_no_errors() {
     };
 
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::start();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 

--- a/tests/chart/bmson/visible_events.rs
+++ b/tests/chart/bmson/visible_events.rs
@@ -3,7 +3,6 @@
 use gametime::{TimeSpan, TimeStamp};
 
 use bms_rs::bmson::parse_bmson;
-use bms_rs::bmson::prelude::BmsonProcessor;
 use bms_rs::chart::prelude::*;
 use strict_num_extended::{FinF64, PositiveF64};
 
@@ -41,7 +40,7 @@ fn test_bmson_visible_events_display_ratio_is_not_all_zero() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::start();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 
@@ -87,7 +86,7 @@ fn test_visible_events_duration_matches_reaction_time() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _start_time = TimeStamp::start();
@@ -137,7 +136,7 @@ fn test_visible_events_duration_with_playback_ratio() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let mut processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
     let _start_time = TimeStamp::start();
@@ -204,7 +203,7 @@ fn test_visible_events_with_boundary_conditions() {
         .generate(&bmson)
         .expect("Failed to generate base BPM in test setup");
     let visible_range_per_bpm = VisibleRangePerBpm::new(base_bpm.value(), reaction_time);
-    let chart = BmsonProcessor::parse(&bmson);
+    let chart = bmson.process().unwrap();
     let start_time = TimeStamp::now();
     let _processor = ChartPlayer::start(&chart, visible_range_per_bpm, start_time);
 


### PR DESCRIPTION
- Add generic type param L to Process trait for key layout mapping
- Make BmsProcessor and BmsonProcessor crate-private
- Remove TryFrom<Bms/Bmson> for Chart (superseded by Process trait)
- All callers use Process::process() uniformly